### PR TITLE
fix(M3-T3): Fix drag regression + Add comprehensive drag E2E tests

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,9 @@
       "Bash(gh run view:*)",
       "Bash(gh pr view:*)",
       "Bash(gh api:*)",
-      "Bash(gh pr:*)"
+      "Bash(gh pr:*)",
+      "Bash(npx playwright test:*)",
+      "WebFetch(domain:playwright.dev)"
     ],
     "deny": []
   },

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: 'html',
+  reporter: [['list'], ['html', { open: 'never' }]],
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',

--- a/app/src/board.worker.ts
+++ b/app/src/board.worker.ts
@@ -49,6 +49,7 @@ self.addEventListener(
   (event: MessageEvent<MainToRendererMessage>) => {
     renderer.handleMessage(event.data).catch((error) => {
       // Catch any unhandled errors from the promise
+      console.error('[Worker] handleMessage error:', error);
       const errorMsg = error instanceof Error ? error.message : String(error);
       self.postMessage({
         type: 'error',

--- a/app/src/renderer/MainThreadRendererAdapter.ts
+++ b/app/src/renderer/MainThreadRendererAdapter.ts
@@ -68,6 +68,8 @@ export class MainThreadRendererAdapter implements IRendererAdapter {
   sendMessage(message: MainToRendererMessage): void {
     // Call handleMessage directly (no postMessage needed)
     this.renderer.handleMessage(message).catch((error) => {
+      console.error('[MainThreadRendererAdapter] handleMessage error:', error);
+
       // Forward any unhandled errors to the message handler
       if (this.messageHandler) {
         const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
Fixed a critical regression where dragging unselected objects stopped working after M3-T3 selection ownership implementation.

## Root Cause
Race condition: selection state updates are async (message-based), but drag needed immediate action. When dragging an unselected object, `selectedObjectIds` wouldn't be updated yet, causing the drag logic to fail.

## Solution
Use `draggedObjectsStartPositions` (the definitive source of what's being dragged) instead of `selectedObjectIds` when:
- Initiating drag (lines 630-656 in RendererCore.ts)
- Updating positions during drag (lines 712-748)
- Clearing drag state on pointer-up (lines 1249-1265)

This ensures we track the correct objects immediately, without waiting for async selection updates.

## Changes
- **RendererCore.ts**: Fixed drag logic to use `draggedObjectsStartPositions` 
- **E2E Tests**: Added 3 comprehensive drag tests:
  1. Dragging unselected object (selects + moves)
  2. Dragging already-selected object (stays selected + moves) 
  3. CMD-dragging unselected object with others selected (all move)
- **Documentation**: Updated CLAUDE.md and M3_yjs_local.md
- **Best Practices**: Added E2E testing guide for canvas pointer events
- **Error Logging**: Improved error handling in worker/adapter

## Test Results
- ✅ All 96 unit tests passing
- ✅ All 38 E2E tests passing (8 selection tests total)
- ✅ Lint + typecheck clean

## Files Changed
- app/src/renderer/RendererCore.ts (drag logic fix)
- app/e2e/selection.spec.ts (3 new tests, +491 lines)
- CLAUDE.md (E2E best practices + M3-T3 completion)
- _plans/M3_yjs_local.md (implementation details)
- app/playwright.config.ts (reporter config)
- app/src/board.worker.ts (error logging)
- app/src/renderer/MainThreadRendererAdapter.ts (error logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)