### PR TITLE
fix(ci): Use correct Railway GraphQL mutation for setting variables

### DIFF
--- a/.github/scripts/deploy-railway.sh
+++ b/.github/scripts/deploy-railway.sh
@@ -81,13 +81,13 @@ if [ -n "$SERVICE_ID" ] && [ "$SERVICE_ID" != "null" ]; then
   echo "Setting PORT=80 environment variable..."
   PORT_MUTATION=$(cat <<EOF
 mutation {
-  variableCollectionUpdate(
+  variableUpsert(
     input: {
+      projectId: "$RAILWAY_PROJECT_ID"
       environmentId: "$RAILWAY_ENVIRONMENT_ID"
       serviceId: "$SERVICE_ID"
-      variables: {
-        PORT: "80"
-      }
+      name: "PORT"
+      value: "80"
     }
   )
 }
@@ -210,13 +210,13 @@ EOF
   echo "Setting PORT=80 environment variable..."
   PORT_MUTATION=$(cat <<EOF
 mutation {
-  variableCollectionUpdate(
+  variableUpsert(
     input: {
+      projectId: "$RAILWAY_PROJECT_ID"
       environmentId: "$RAILWAY_ENVIRONMENT_ID"
       serviceId: "$SERVICE_ID"
-      variables: {
-        PORT: "80"
-      }
+      name: "PORT"
+      value: "80"
     }
   )
 }


### PR DESCRIPTION
## Summary

Fixes the Railway deployment script to use the correct GraphQL mutation for setting environment variables.

## Changes

- Changed from incorrect `variableCollectionUpdate` to correct `variableUpsert`
- Updated both redeploy and new service creation code paths
- Now uses proper parameters per Railway API docs:
  - `projectId`
  - `environmentId`
  - `serviceId`
  - `name: "PORT"`
  - `value: "80"`

## Why

The previous mutation name `variableCollectionUpdate` was incorrect and would fail when trying to set the PORT environment variable on Railway services.

## Reference

Railway API Documentation: https://docs.railway.com/guides/manage-variables

## Testing

This will be tested when the PR is merged and the next deployment runs.