### PR TITLE
fix: Improve E2E test reliability with renderer-side pending operations counter

### DIFF
--- a/app/e2e/selection.spec.ts
+++ b/app/e2e/selection.spec.ts
@@ -726,12 +726,16 @@ test.describe('Selection Ownership E2E', () => {
   test('CMD-dragging an unselected object with other selected objects moves all', async ({
     page,
   }) => {
+    console.log('[E2E-TEST] ========== TEST START ==========');
+
     // Reset to test scene
+    console.log('[E2E-TEST] Step 1: Reset to test scene');
     await page.click('button:has-text("Reset to Test Scene")');
     await expect(page.locator('text=Objects: 15')).toBeVisible();
     await page.waitForTimeout(500);
 
     // Get two objects
+    console.log('[E2E-TEST] Step 2: Get object data from store');
     const objectsData = await page.evaluate(() => {
       const __TEST_STORE__ = (globalThis as any).__TEST_STORE__ as TestStore;
       const canvas = document.querySelector('canvas');
@@ -766,12 +770,14 @@ test.describe('Selection Ownership E2E', () => {
     });
 
     if (!objectsData) throw new Error('No objects found');
+    console.log('[E2E-TEST] Object data:', objectsData);
 
     const canvas = page.locator('canvas');
     const canvasBBox = await canvas.boundingBox();
     if (!canvasBBox) throw new Error('Canvas not found');
 
     // Select first object (without CMD)
+    console.log('[E2E-TEST] Step 3: Click obj1 to select it (without CMD)');
     const click1X = canvasBBox.x + objectsData.obj1.screenPos.x;
     const click1Y = canvasBBox.y + objectsData.obj1.screenPos.y;
 
@@ -802,12 +808,16 @@ test.describe('Selection Ownership E2E', () => {
     });
 
     // Wait for first object's selection to complete and render before starting CMD-drag
+    console.log('[E2E-TEST] Step 4: Wait for obj1 selection to propagate');
     await page.evaluate(async () => {
       const __TEST_BOARD__ = (globalThis as any).__TEST_BOARD__ as TestBoard;
+      console.log('[E2E-TEST] Calling waitForRenderer()...');
       await __TEST_BOARD__.waitForRenderer();
+      console.log('[E2E-TEST] waitForRenderer() completed');
     });
 
     // Now CMD-drag the second object
+    console.log('[E2E-TEST] Step 5: CMD+drag obj2');
     const click2X = canvasBBox.x + objectsData.obj2.screenPos.x;
     const click2Y = canvasBBox.y + objectsData.obj2.screenPos.y;
     const dragDeltaX = 100;


### PR DESCRIPTION
## Summary

Fixes flaky E2E selection tests by moving the pending operations counter from Board to Renderer, ensuring `waitForRenderer()` waits for the complete round-trip: Renderer → Board → Store → Renderer → `syncSelectionCache()`.

Also adds comprehensive debug logging throughout the message flow to diagnose potential remote CI failures.

## Problem

The E2E test "CMD-dragging an unselected object with other selected objects moves all" was failing intermittently because `waitForRenderer()` returned before the renderer's `selectedObjectIds` cache was fully synced with the store.

**Root cause**: The pending operations counter was on the Board side and decremented when Board received the message from Renderer, but BEFORE the full round-trip completed (Store → Renderer → cache sync).

## Solution

### 1. Renderer-Side Pending Operations Counter

**Moved counter from Board.tsx → RendererCore.ts:**

- **Increment**: `handlePointerDown()` when `event.isPrimary` (RendererCore.ts:676-681)
- **Decrement**: `syncSelectionCache()` after cache update (RendererCore.ts:1876-1882)
- **Flush handler**: Polls renderer's counter until 0 (RendererCore.ts:311-365)

**Removed all Board-side counter logic** per feedback to avoid confusion.

### 2. Comprehensive Debug Logging

Added logging throughout the entire message flow for remote CI diagnostics:

**Board.tsx:**
- Log when `objects-selected/moved/unselected` messages arrive from renderer
- Log when `selectObjects/moveObjects/unselectObjects` store actions complete
- Log when Yjs observer forwards `objects-updated` back to renderer

**RendererCore.ts:**
- Existing drag decision point logging (shows `selectedObjectIds` state)
- Existing `syncSelectionCache()` logging (shows cache updates)
- Existing pending operations counter logging

**Complete visibility:**
- ✅ Renderer decision point (what renderer "sees")
- ✅ Board message receipt (renderer → board)
- ✅ Store action completion (board → store)
- ✅ Yjs observer updates (store → board → renderer)
- ✅ Cache sync (renderer final state)

## Testing

- ✅ All 38 E2E tests passing locally
- ✅ Specific CMD-drag test verified multiple times
- ✅ Typecheck passing
- ✅ No lint/format issues

## Files Changed

- `app/src/renderer/RendererCore.ts`: Renderer-side counter + existing debug logs
- `app/src/components/Board.tsx`: Removed Board-side counter + added message flow debug logs
- `app/e2e/selection.spec.ts`: Enhanced test logging

## Related

- Addresses flaky test failures observed in previous sessions
- Implements "Option 3" from architectural discussion (fix `waitForRenderer()` properly)
- Maintains Yjs store as single source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)