### PR TITLE
fix: Only deploy to Railway when Docker build actually runs

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -214,7 +214,7 @@ jobs:
   deploy-railway-server:
     runs-on: ubuntu-latest
     needs: docker-build-server
-    if: github.event.pull_request.head.repo.full_name == github.repository && needs.docker-build-server.result == 'success'
+    if: github.event.pull_request.head.repo.full_name == github.repository && needs.docker-build-server.result == 'success' && needs.docker-build-server.outputs.build_needed == 'true'
     outputs:
       server_url: ${{ steps.deploy.outputs.url }}
     environment:
@@ -237,7 +237,7 @@ jobs:
   deploy-railway-app:
     runs-on: ubuntu-latest
     needs: docker-build-app
-    if: github.event.pull_request.head.repo.full_name == github.repository && needs.docker-build-app.result == 'success'
+    if: github.event.pull_request.head.repo.full_name == github.repository && needs.docker-build-app.result == 'success' && needs.docker-build-app.outputs.build_needed == 'true'
     environment:
       name: pr-${{ github.event.pull_request.number }}-app
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## Summary

Fixes an issue where Railway deployments were triggered on every PR push, even when the Docker build was skipped (no changes detected).

## Problem

The PR deployment workflow was checking if the Docker build job succeeded, but in GitHub Actions, a skipped step is still considered "successful". This meant:
- Docker build skipped (no changes) → result = 'success'
- Deployment job runs → unnecessary Railway deployment

## Solution

Added an additional check to verify the build was actually needed:
- Check both `result == 'success'` AND `outputs.build_needed == 'true'`
- Deployment only runs when Docker image was actually built

## Impact

- Saves Railway deployment costs on PRs without server/app changes
- Reduces deployment time for PRs that only touch documentation, tests, or other non-deployable code
- No impact on deployment behavior when changes are detected

## Testing

- Workflow file changes only
- Will verify on next PR push that doesn't touch server/app code