### PR TITLE
Phase 2: Eager plugin load + cache + pluginId rename (ct-4wk)

### DIFF
--- a/app/src/__tests__/routes/table.$id.test.tsx
+++ b/app/src/__tests__/routes/table.$id.test.tsx
@@ -91,7 +91,6 @@ vi.mock('../../store/YjsStore', () => {
 // Mock the content module to capture loadPluginAssets calls without doing
 // real network IO.
 const loadPluginAssetsMock = vi.fn<(pluginId: string) => Promise<GameAssets>>();
-const reloadScenarioFromMetadataMock = vi.fn();
 
 const emptyAssets: GameAssets = {
   packs: [],
@@ -113,9 +112,6 @@ vi.mock('../../content', async () => {
     ...actual,
     loadPluginAssets: (pluginId: string): Promise<GameAssets> =>
       loadPluginAssetsMock(pluginId),
-    reloadScenarioFromMetadata: (
-      metadata: ContentModule.LoadedScenarioMetadata,
-    ): unknown => reloadScenarioFromMetadataMock(metadata),
   };
 });
 
@@ -127,7 +123,6 @@ describe('Table Route', () => {
     }
     setGameAssetsMock.mockClear();
     loadPluginAssetsMock.mockReset();
-    reloadScenarioFromMetadataMock.mockReset();
     loadPluginAssetsMock.mockResolvedValue(emptyAssets);
   });
 
@@ -178,8 +173,6 @@ describe('Table Route', () => {
 
     expect(loadPluginAssetsMock).toHaveBeenCalledTimes(1);
     expect(loadPluginAssetsMock).toHaveBeenCalledWith('test-plugin');
-    // No scenario metadata was set, so reloadScenarioFromMetadata must not run.
-    expect(reloadScenarioFromMetadataMock).not.toHaveBeenCalled();
     // setGameAssets called exactly once on the no-scenario happy path.
     expect(setGameAssetsMock).toHaveBeenCalledTimes(1);
     expect(setGameAssetsMock).toHaveBeenCalledWith(emptyAssets);

--- a/app/src/__tests__/routes/table.$id.test.tsx
+++ b/app/src/__tests__/routes/table.$id.test.tsx
@@ -185,12 +185,11 @@ describe('Table Route', () => {
     expect(setGameAssetsMock).toHaveBeenCalledWith(emptyAssets);
   });
 
-  it('tolerates legacy gameId metadata key for plugin lookup', async () => {
-    // Pre-migration table: only the legacy 'gameId' key is present.
-    mockMetadata.set('gameId', 'legacy-plugin');
+  it('skips plugin loading when no pluginId metadata is set', async () => {
+    // No pluginId set — blank table state.
 
     const memoryHistory = createMemoryHistory({
-      initialEntries: ['/table/legacy-table'],
+      initialEntries: ['/table/blank-table'],
     });
     const router = createRouter({
       routeTree,
@@ -205,6 +204,7 @@ describe('Table Route', () => {
 
     await screen.findByTestId('board');
 
-    expect(loadPluginAssetsMock).toHaveBeenCalledWith('legacy-plugin');
+    expect(loadPluginAssetsMock).not.toHaveBeenCalled();
+    expect(setGameAssetsMock).not.toHaveBeenCalled();
   });
 });

--- a/app/src/__tests__/routes/table.$id.test.tsx
+++ b/app/src/__tests__/routes/table.$id.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
 import {
   createMemoryHistory,
@@ -8,6 +8,16 @@ import {
 } from '@tanstack/react-router';
 import { routeTree } from '../../routeTree.gen';
 import * as Y from 'yjs';
+import type { GameAssets } from '@cardtable2/shared';
+import type * as ContentModule from '../../content';
+
+// ---------------------------------------------------------------------------
+// Shared mock state (so tests can pre-set metadata before mount)
+// ---------------------------------------------------------------------------
+
+const mockDoc = new Y.Doc();
+const mockMetadata = mockDoc.getMap<unknown>('metadata');
+const setGameAssetsMock = vi.fn();
 
 // Mock the Board component since it's lazy loaded
 vi.mock('../../components/Board', () => ({
@@ -18,11 +28,10 @@ vi.mock('../../components/Board', () => ({
 
 // Mock YjsStore since it's used by the Table route (M3.6-T5)
 vi.mock('../../store/YjsStore', () => {
-  const mockDoc = new Y.Doc();
   return {
     YjsStore: class MockYjsStore {
       objects = mockDoc.getMap('objects');
-      metadata = mockDoc.getMap('metadata');
+      metadata = mockMetadata;
       hands = mockDoc.getMap('hands');
       async waitForReady() {
         return Promise.resolve();
@@ -48,7 +57,9 @@ vi.mock('../../store/YjsStore', () => {
       getActorId() {
         return 'test-actor-id';
       }
-      setGameAssets(_assets: unknown) {}
+      setGameAssets(assets: unknown) {
+        setGameAssetsMock(assets);
+      }
       getGameAssets() {
         return null;
       }
@@ -77,7 +88,49 @@ vi.mock('../../store/YjsStore', () => {
   };
 });
 
+// Mock the content module to capture loadPluginAssets calls without doing
+// real network IO.
+const loadPluginAssetsMock = vi.fn<(pluginId: string) => Promise<GameAssets>>();
+const reloadScenarioFromMetadataMock = vi.fn();
+
+const emptyAssets: GameAssets = {
+  packs: [],
+  cardTypes: {},
+  cards: {},
+  cardSets: {},
+  tokens: {},
+  counters: {},
+  mats: {},
+  tokenTypes: {},
+  statusTypes: {},
+  modifierStats: {},
+  iconTypes: {},
+};
+
+vi.mock('../../content', async () => {
+  const actual = await vi.importActual<typeof ContentModule>('../../content');
+  return {
+    ...actual,
+    loadPluginAssets: (pluginId: string): Promise<GameAssets> =>
+      loadPluginAssetsMock(pluginId),
+    reloadScenarioFromMetadata: (
+      metadata: ContentModule.LoadedScenarioMetadata,
+    ): unknown => reloadScenarioFromMetadataMock(metadata),
+  };
+});
+
 describe('Table Route', () => {
+  beforeEach(() => {
+    // Clear shared metadata between tests
+    for (const key of Array.from(mockMetadata.keys())) {
+      mockMetadata.delete(key);
+    }
+    setGameAssetsMock.mockClear();
+    loadPluginAssetsMock.mockReset();
+    reloadScenarioFromMetadataMock.mockReset();
+    loadPluginAssetsMock.mockResolvedValue(emptyAssets);
+  });
+
   it('renders with table ID from route', async () => {
     const memoryHistory = createMemoryHistory({
       initialEntries: ['/table/happy-clever-elephant'],
@@ -100,5 +153,58 @@ describe('Table Route', () => {
     expect(
       screen.getByText(/Board: happy-clever-elephant/i),
     ).toBeInTheDocument();
+  });
+
+  it('always loads plugin assets on mount when pluginId metadata is set', async () => {
+    // Pre-seed pluginId metadata BEFORE mount so the mount effect sees it.
+    mockMetadata.set('pluginId', 'test-plugin');
+
+    const memoryHistory = createMemoryHistory({
+      initialEntries: ['/table/eager-load-table'],
+    });
+    const router = createRouter({
+      routeTree,
+      history: memoryHistory,
+      defaultPendingMinMs: 0,
+    });
+
+    await act(async () => {
+      render(<RouterProvider router={router} />);
+      await router.load();
+    });
+
+    // Wait until Board renders (which happens after pack loading completes)
+    await screen.findByTestId('board');
+
+    expect(loadPluginAssetsMock).toHaveBeenCalledTimes(1);
+    expect(loadPluginAssetsMock).toHaveBeenCalledWith('test-plugin');
+    // No scenario metadata was set, so reloadScenarioFromMetadata must not run.
+    expect(reloadScenarioFromMetadataMock).not.toHaveBeenCalled();
+    // setGameAssets called exactly once on the no-scenario happy path.
+    expect(setGameAssetsMock).toHaveBeenCalledTimes(1);
+    expect(setGameAssetsMock).toHaveBeenCalledWith(emptyAssets);
+  });
+
+  it('tolerates legacy gameId metadata key for plugin lookup', async () => {
+    // Pre-migration table: only the legacy 'gameId' key is present.
+    mockMetadata.set('gameId', 'legacy-plugin');
+
+    const memoryHistory = createMemoryHistory({
+      initialEntries: ['/table/legacy-table'],
+    });
+    const router = createRouter({
+      routeTree,
+      history: memoryHistory,
+      defaultPendingMinMs: 0,
+    });
+
+    await act(async () => {
+      render(<RouterProvider router={router} />);
+      await router.load();
+    });
+
+    await screen.findByTestId('board');
+
+    expect(loadPluginAssetsMock).toHaveBeenCalledWith('legacy-plugin');
   });
 });

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -410,17 +410,13 @@ export function registerDefaultActions(): void {
     description: 'Load the first scenario for the current game',
     isAvailable: (ctx) => {
       // Only available when nothing selected and a plugin is bound to the
-      // table. Reads tolerate the legacy 'gameId' key (Phase 4 migrates).
-      const pluginId =
-        (ctx.store.metadata.get('pluginId') as string | undefined) ??
-        (ctx.store.metadata.get('gameId') as string | undefined);
+      // table.
+      const pluginId = ctx.store.metadata.get('pluginId') as string | undefined;
       return ctx.selection.count === 0 && pluginId !== undefined;
     },
     execute: async (ctx) => {
       try {
-        const pluginId =
-          (ctx.store.metadata.get('pluginId') as string | undefined) ??
-          (ctx.store.metadata.get('gameId') as string);
+        const pluginId = ctx.store.metadata.get('pluginId') as string;
 
         console.log(`[Load Scenario] Loading scenario for plugin: ${pluginId}`);
 
@@ -459,9 +455,7 @@ export function registerDefaultActions(): void {
           error instanceof Error ? error.message : String(error);
         console.error('[Load Scenario] Failed to load scenario', {
           errorId: ACTION_LOAD_SCENARIO_FAILED,
-          pluginId:
-            ctx.store.metadata.get('pluginId') ??
-            ctx.store.metadata.get('gameId'),
+          pluginId: ctx.store.metadata.get('pluginId'),
           error: errorMessage,
         });
         alert(`Failed to load scenario: ${errorMessage}`);

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -15,7 +15,8 @@ import {
   areAllSelectedStacksReady,
 } from '../store/YjsSelectors';
 import {
-  loadPluginScenario,
+  loadPluginAssets,
+  loadScenarioFromPlugin,
   loadLocalPluginScenario,
   loadPlugin,
   type LoadedScenarioMetadata,
@@ -420,15 +421,31 @@ export function registerDefaultActions(): void {
 
         console.log(`[Load Scenario] Loading scenario for plugin: ${pluginId}`);
 
-        // Load plugin to get its first scenario
+        // Load plugin manifest (cached) to get its first scenario.
         const plugin = await loadPlugin(pluginId);
         const scenarioFile = plugin.manifest.scenarios[0];
         if (!scenarioFile) {
           throw new Error(`Plugin "${pluginId}" has no scenarios`);
         }
 
-        // Load scenario through plugin system (loads ALL plugin packs)
-        const content = await loadPluginScenario(pluginId, scenarioFile);
+        // Use already-loaded plugin assets from the store (cached on table
+        // mount). Defensive fallback to loadPluginAssets — should be a cache
+        // hit on the happy path because the table-mount effect already
+        // populated the cache.
+        let gameAssets = ctx.store.getGameAssets();
+        if (!gameAssets) {
+          console.log(
+            '[Load Scenario] No gameAssets in store; loading plugin assets',
+          );
+          gameAssets = await loadPluginAssets(pluginId);
+        }
+
+        // Pure scenario load: fetches scenario JSON only, no asset packs.
+        const content = await loadScenarioFromPlugin(
+          pluginId,
+          scenarioFile,
+          gameAssets,
+        );
 
         console.log(
           `[Load Scenario] Loaded ${content.objects.size} objects from scenario: ${content.scenario.name}`,
@@ -582,10 +599,23 @@ export function registerDefaultActions(): void {
 
       try {
         console.log('[Load Marvel Champions] Loading Rhino scenario...');
-        const [content, plugin] = await Promise.all([
-          loadPluginScenario(pluginId, scenarioFile),
-          loadPlugin(pluginId),
-        ]);
+
+        // Plugin lookup served from cache after first load.
+        const plugin = await loadPlugin(pluginId);
+
+        // Reuse already-loaded plugin assets if available; otherwise hit the
+        // plugin cache to load + merge them. Either way, NO duplicate
+        // pack-fetches inside the scenario load.
+        let gameAssets = ctx.store.getGameAssets();
+        if (!gameAssets) {
+          gameAssets = await loadPluginAssets(pluginId);
+        }
+
+        const content = await loadScenarioFromPlugin(
+          pluginId,
+          scenarioFile,
+          gameAssets,
+        );
 
         // Store metadata for plugin scenarios (can auto-reload)
         const metadata: LoadedScenarioMetadata = {

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -409,13 +409,18 @@ export function registerDefaultActions(): void {
     category: 'Global Actions',
     description: 'Load the first scenario for the current game',
     isAvailable: (ctx) => {
-      // Only available when nothing selected and gameId exists
-      const gameId = ctx.store.metadata.get('gameId') as string | undefined;
-      return ctx.selection.count === 0 && gameId !== undefined;
+      // Only available when nothing selected and a plugin is bound to the
+      // table. Reads tolerate the legacy 'gameId' key (Phase 4 migrates).
+      const pluginId =
+        (ctx.store.metadata.get('pluginId') as string | undefined) ??
+        (ctx.store.metadata.get('gameId') as string | undefined);
+      return ctx.selection.count === 0 && pluginId !== undefined;
     },
     execute: async (ctx) => {
       try {
-        const pluginId = ctx.store.metadata.get('gameId') as string;
+        const pluginId =
+          (ctx.store.metadata.get('pluginId') as string | undefined) ??
+          (ctx.store.metadata.get('gameId') as string);
 
         console.log(`[Load Scenario] Loading scenario for plugin: ${pluginId}`);
 
@@ -454,7 +459,9 @@ export function registerDefaultActions(): void {
           error instanceof Error ? error.message : String(error);
         console.error('[Load Scenario] Failed to load scenario', {
           errorId: ACTION_LOAD_SCENARIO_FAILED,
-          gameId: ctx.store.metadata.get('gameId'),
+          pluginId:
+            ctx.store.metadata.get('pluginId') ??
+            ctx.store.metadata.get('gameId'),
           error: errorMessage,
         });
         alert(`Failed to load scenario: ${errorMessage}`);

--- a/app/src/content/index.test.ts
+++ b/app/src/content/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { findBlobUrl, replaceImagePathsWithBlobUrls } from './index';
-import type { GameAssets } from '@cardtable2/shared';
+import {
+  findBlobUrl,
+  loadScenarioFromPlugin,
+  replaceImagePathsWithBlobUrls,
+} from './index';
+import { __resetPluginCacheForTests } from './pluginLoader';
+import type { GameAssets, Scenario } from '@cardtable2/shared';
 
 /**
  * Helper: build a minimal GameAssets for testing.
@@ -351,5 +356,170 @@ describe('replaceImagePathsWithBlobUrls', () => {
       key: 'extra',
       path: 'tokens/extra-damage.png',
     });
+  });
+});
+
+// ============================================================================
+// loadScenarioFromPlugin Tests
+// ============================================================================
+
+describe('loadScenarioFromPlugin', () => {
+  let originalFetch: typeof global.fetch;
+
+  const pluginRegistry = {
+    plugins: [
+      {
+        id: 'test-plugin',
+        name: 'Test Plugin',
+        author: 'Test',
+        description: 'desc',
+        baseUrl: 'https://example.com/plugins/test/',
+        boxArt: 'https://example.com/plugins/test/box.png',
+      },
+    ],
+  };
+
+  const pluginManifest = {
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    version: '1.0.0',
+    assets: ['pack-a.json', 'pack-b.json'],
+    scenarios: ['scenario-1.json'],
+  };
+
+  const scenarioJson: Scenario = {
+    schema: 'ct-scenario@2',
+    id: 'scenario-1',
+    name: 'Test Scenario',
+    version: '1.0.0',
+    packs: [],
+  };
+
+  beforeEach(() => {
+    __resetPluginCacheForTests();
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('does not fetch or merge asset packs', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === '/pluginsIndex.json') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pluginRegistry),
+        });
+      }
+      if (url.endsWith('index.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pluginManifest),
+        });
+      }
+      if (url.endsWith('scenario-1.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(scenarioJson),
+        });
+      }
+      throw new Error(
+        `Unexpected fetch in loadScenarioFromPlugin test: ${url}`,
+      );
+    });
+    global.fetch = fetchMock;
+
+    const gameAssets: GameAssets = {
+      packs: [],
+      cardTypes: {},
+      cards: {},
+      cardSets: {},
+      tokens: {},
+      counters: {},
+      mats: {},
+      tokenTypes: {},
+      statusTypes: {},
+      modifierStats: {},
+      iconTypes: {},
+    };
+
+    const result = await loadScenarioFromPlugin(
+      'test-plugin',
+      'scenario-1.json',
+      gameAssets,
+    );
+
+    // Returned content reuses the supplied gameAssets reference (no new merge).
+    expect(result.content).toBe(gameAssets);
+    expect(result.scenario).toEqual(scenarioJson);
+
+    // No pack URLs were fetched. Allowed: registry, manifest, scenario JSON.
+    // This is the whole point of the split — scenario load is pure.
+    const fetchedUrls = fetchMock.mock.calls.map((call) => call[0] as string);
+    const packUrls = fetchedUrls.filter((u) => u.includes('pack-'));
+    expect(packUrls).toHaveLength(0);
+
+    // The exact set of fetches should be: registry + plugin manifest + scenario.
+    expect(fetchedUrls).toHaveLength(3);
+    expect(fetchedUrls).toContain('/pluginsIndex.json');
+    expect(
+      fetchedUrls.some(
+        (u) => u === 'https://example.com/plugins/test/index.json',
+      ),
+    ).toBe(true);
+    expect(
+      fetchedUrls.some(
+        (u) => u === 'https://example.com/plugins/test/scenario-1.json',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns objects produced by instantiateScenario over the supplied gameAssets', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url === '/pluginsIndex.json') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pluginRegistry),
+        });
+      }
+      if (url.endsWith('index.json')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pluginManifest),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(scenarioJson),
+      });
+    });
+
+    const gameAssets: GameAssets = {
+      packs: [],
+      cardTypes: {},
+      cards: {},
+      cardSets: {},
+      tokens: {},
+      counters: {},
+      mats: {},
+      tokenTypes: {},
+      statusTypes: {},
+      modifierStats: {},
+      iconTypes: {},
+    };
+
+    const result = await loadScenarioFromPlugin(
+      'test-plugin',
+      'scenario-1.json',
+      gameAssets,
+    );
+
+    // Empty `packs` in the scenario means instantiateScenario produces no
+    // objects — the contract here is that it ran and returned a Map. The
+    // important behavior is verified in the previous test: no pack fetches.
+    expect(result.objects).toBeInstanceOf(Map);
+    // gameAssets reference is preserved.
+    expect(result.content).toBe(gameAssets);
   });
 });

--- a/app/src/content/index.ts
+++ b/app/src/content/index.ts
@@ -212,45 +212,46 @@ export async function loadPluginAssets(pluginId: string): Promise<GameAssets> {
 // ============================================================================
 
 /**
- * Load a scenario from a plugin
+ * Load a scenario from a plugin against already-resident game assets.
  *
- * This loads a scenario from a plugin repository, fetching all required
- * asset packs and instantiating the scenario objects.
+ * This is the pure scenario-load path: fetch the scenario JSON, instantiate
+ * objects against the supplied `gameAssets`. It does NOT fetch asset packs.
  *
- * @param pluginId - The plugin ID from pluginsIndex.json
+ * Callers are expected to have already loaded the plugin's assets (e.g. via
+ * `loadPluginAssets` on table mount, served from the plugin cache). On the
+ * happy path this is a single network request — the scenario JSON — plus a
+ * synchronous `instantiateScenario` call.
+ *
+ * @param pluginId - The plugin ID from pluginsIndex.json (used to resolve the
+ *   scenario URL via the plugin registry)
  * @param scenarioFilename - The scenario filename from the plugin manifest
- * @returns Complete loaded content ready to be added to Y.Doc
+ * @param gameAssets - Already-loaded game assets the scenario instantiates
+ *   against
+ * @returns Complete loaded content; `content` is the same `gameAssets`
+ *   reference passed in (no merge happens here)
  *
  * @example
  * ```typescript
- * const content = await loadPluginScenario('marvel-champions', 'marvelchampions-rhino-scenario.json');
- * // Add objects to Y.Doc
+ * const gameAssets = store.getGameAssets() ?? await loadPluginAssets(pluginId);
+ * const content = await loadScenarioFromPlugin(pluginId, 'rhino-scenario.json', gameAssets);
  * for (const [id, obj] of content.objects) {
- *   store.addObject(id, obj);
+ *   store.setObject(id, obj);
  * }
  * ```
  */
-export async function loadPluginScenario(
+export async function loadScenarioFromPlugin(
   pluginId: string,
   scenarioFilename: string,
+  gameAssets: GameAssets,
 ): Promise<LoadedContent> {
-  // Load plugin manifest
+  // Plugin lookup is served from the in-flight cache on the happy path.
   const plugin = await loadPlugin(pluginId);
-  const baseUrl = plugin.registry.baseUrl.replace(/\/$/, '');
 
-  // Load ALL asset packs from the plugin manifest (not just scenario.packs)
-  const packUrls = plugin.manifest.assets.map(
-    (filename) => `${baseUrl}/${filename}`,
-  );
-  const packs = await loadAssetPacks(packUrls);
-  const content = mergeAssetPacks(packs, baseUrl);
-
-  // Load and instantiate scenario
   const scenarioUrl = getPluginScenarioUrl(plugin, scenarioFilename);
   const scenario = await loadScenario(scenarioUrl);
-  const objects = instantiateScenario(scenario, content);
+  const objects = instantiateScenario(scenario, gameAssets);
 
-  return { scenario, content, objects };
+  return { scenario, content: gameAssets, objects };
 }
 
 /**
@@ -316,78 +317,6 @@ export async function loadLocalPluginScenario(
     pluginManifest: plugin.manifest,
     blobUrls: plugin.imageUrls,
   };
-}
-
-/**
- * Reload a scenario from stored metadata
- *
- * This function is called on table mount to restore previously loaded scenarios.
- * It reads the metadata from Y.Doc and reloads the appropriate scenario type.
- *
- * Note: 'local-dev' type scenarios cannot be reloaded (require user interaction)
- *
- * @param metadata - Loaded scenario metadata from Y.Doc
- * @returns Complete loaded content ready to be set as gameAssets
- * @throws Error if scenario cannot be reloaded or metadata is invalid
- *
- * @example
- * ```typescript
- * const metadata = store.metadata.get('loadedScenario');
- * if (metadata) {
- *   const content = await reloadScenarioFromMetadata(metadata);
- *   setGameAssets(content.content);
- * }
- * ```
- */
-export async function reloadScenarioFromMetadata(
-  metadata: LoadedScenarioMetadata,
-): Promise<LoadedContent> {
-  console.log('[Content] Reloading scenario from metadata:', {
-    type: metadata.type,
-    scenarioName: metadata.scenarioName,
-    loadedAt: new Date(metadata.loadedAt).toISOString(),
-  });
-
-  switch (metadata.type) {
-    case 'plugin':
-      // Type system guarantees pluginId and scenarioFile are present
-      return loadPluginScenario(metadata.pluginId, metadata.scenarioFile);
-
-    case 'builtin':
-      // Type system guarantees scenarioUrl is present
-      return loadCompleteScenario(metadata.scenarioUrl);
-
-    case 'local-dev':
-      console.error('[Content] Cannot reload local-dev scenario', {
-        errorId: 'CONTENT_RELOAD_LOCAL_DEV_UNSUPPORTED',
-        metadata,
-      });
-      throw new Error(
-        'Cannot automatically reload local-dev scenarios (requires user interaction)',
-      );
-
-    default: {
-      // TypeScript exhaustiveness checking means metadata is 'never' here.
-      // However, since metadata comes from Y.Doc (potentially corrupted/stale),
-      // we handle unexpected runtime values defensively.
-      const unknownMetadata = metadata as { type?: unknown };
-      const typeValue = unknownMetadata.type;
-      const unknownType =
-        typeof typeValue === 'string' ||
-        typeof typeValue === 'number' ||
-        typeof typeValue === 'boolean'
-          ? String(typeValue)
-          : 'undefined';
-      console.error('[Content] Unknown metadata type during scenario reload', {
-        errorId: 'CONTENT_RELOAD_UNKNOWN_TYPE',
-        receivedType: unknownType,
-        metadata: unknownMetadata,
-      });
-      throw new Error(
-        `Cannot reload scenario: unknown metadata type "${unknownType}".`,
-      );
-    }
-  }
 }
 
 /**

--- a/app/src/content/pluginLoader.test.ts
+++ b/app/src/content/pluginLoader.test.ts
@@ -6,6 +6,7 @@ import {
   loadPlugin,
   loadLocalPluginDirectory,
   getLocalPluginFile,
+  __resetPluginCacheForTests,
   type PluginRegistry,
   type PluginManifest,
   type PluginRegistryEntry,
@@ -465,6 +466,7 @@ describe('loadPlugin', () => {
 
   beforeEach(() => {
     originalFetch = global.fetch;
+    __resetPluginCacheForTests();
   });
 
   afterEach(() => {
@@ -524,6 +526,124 @@ describe('loadPlugin', () => {
     });
 
     await expect(loadPlugin('test-plugin')).rejects.toThrow();
+  });
+});
+
+// ============================================================================
+// loadPlugin Cache Tests
+// ============================================================================
+
+describe('loadPlugin cache', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    __resetPluginCacheForTests();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should dedupe two concurrent calls into a single fetch', async () => {
+    // Use a deferred promise so both callers are guaranteed to be in-flight
+    // when the fetch resolves.
+    let resolveRegistryFetch!: (value: unknown) => void;
+    const registryFetchGate = new Promise<unknown>((resolve) => {
+      resolveRegistryFetch = resolve;
+    });
+
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === '/pluginsIndex.json') {
+        return registryFetchGate.then((data) => ({
+          ok: true,
+          json: () => Promise.resolve(data),
+        }));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockManifest),
+      });
+    });
+    global.fetch = fetchMock;
+
+    // Kick off two concurrent calls — both should share one in-flight fetch.
+    const p1 = loadPlugin('test-plugin');
+    const p2 = loadPlugin('test-plugin');
+
+    // The cache stores the SAME Promise — verify referential identity.
+    // (This is the property the implementation must preserve to dedupe.)
+    expect(p1).toBe(p2);
+
+    // Now release the registry fetch.
+    resolveRegistryFetch(mockRegistry);
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe(r2);
+    // Exactly one registry fetch and one manifest fetch despite two callers.
+    const registryCalls = fetchMock.mock.calls.filter(
+      (call) => call[0] === '/pluginsIndex.json',
+    );
+    expect(registryCalls).toHaveLength(1);
+    const manifestCalls = fetchMock.mock.calls.filter(
+      (call) => call[0] !== '/pluginsIndex.json',
+    );
+    expect(manifestCalls).toHaveLength(1);
+  });
+
+  it('should serve completed entries from cache without re-fetching', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === '/pluginsIndex.json') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRegistry),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockManifest),
+      });
+    });
+    global.fetch = fetchMock;
+
+    const r1 = await loadPlugin('test-plugin');
+    const callsAfterFirst = fetchMock.mock.calls.length;
+
+    const r2 = await loadPlugin('test-plugin');
+
+    expect(r2).toBe(r1);
+    // No additional fetches on the second call.
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('should evict failed entries so subsequent callers can retry', async () => {
+    // First call: registry fetch fails.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+    });
+
+    await expect(loadPlugin('test-plugin')).rejects.toThrow();
+
+    // Second call: registry fetch succeeds. Should NOT replay the cached
+    // failure.
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url === '/pluginsIndex.json') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRegistry),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockManifest),
+      });
+    });
+
+    const result = await loadPlugin('test-plugin');
+    expect(result.registry.id).toBe('test-plugin');
   });
 });
 

--- a/app/src/content/pluginLoader.ts
+++ b/app/src/content/pluginLoader.ts
@@ -268,12 +268,34 @@ export async function loadAllPlugins(): Promise<LoadedPlugin[]> {
   return loaded;
 }
 
+// ============================================================================
+// Plugin Cache
+// ============================================================================
+
 /**
- * Load a single plugin by ID
+ * In-flight + completed plugin cache, keyed by pluginId.
  *
- * @throws {Error} If plugin not found in registry or loading fails
+ * Stores `Promise<LoadedPlugin>` (not the resolved value) so concurrent callers
+ * with the same pluginId share a single underlying fetch — including the
+ * "mount effect kicks off plugin load → user immediately triggers Load
+ * Scenario" race.
+ *
+ * If the underlying load fails the rejected entry is evicted so subsequent
+ * callers retry rather than getting a permanently-cached error.
+ *
+ * Module-level scope is intentional: plugins are immutable for a session and
+ * sharing across route changes / store instances is desirable.
  */
-export async function loadPlugin(pluginId: string): Promise<LoadedPlugin> {
+const pluginCache = new Map<string, Promise<LoadedPlugin>>();
+
+/**
+ * Reset the plugin cache. Test-only helper; do not call from app code.
+ */
+export function __resetPluginCacheForTests(): void {
+  pluginCache.clear();
+}
+
+async function fetchPluginFresh(pluginId: string): Promise<LoadedPlugin> {
   const registry = await loadPluginRegistry();
   const entry = registry.plugins.find((p) => p.id === pluginId);
 
@@ -288,6 +310,35 @@ export async function loadPlugin(pluginId: string): Promise<LoadedPlugin> {
 
   const manifest = await loadPluginManifest(entry.baseUrl);
   return { registry: entry, manifest };
+}
+
+/**
+ * Load a single plugin by ID, deduping concurrent calls via an in-flight
+ * cache.
+ *
+ * The cache stores the in-flight Promise so two near-simultaneous callers
+ * (e.g. the mount effect and an immediate Load-Scenario click) share one
+ * fetch. Successful results stay cached for the session; rejections are
+ * evicted so callers can retry.
+ *
+ * @throws {Error} If plugin not found in registry or loading fails
+ */
+export function loadPlugin(pluginId: string): Promise<LoadedPlugin> {
+  const cached = pluginCache.get(pluginId);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = fetchPluginFresh(pluginId).catch((err: unknown) => {
+    // Evict failed entries so subsequent callers retry.
+    if (pluginCache.get(pluginId) === promise) {
+      pluginCache.delete(pluginId);
+    }
+    throw err;
+  });
+
+  pluginCache.set(pluginId, promise);
+  return promise;
 }
 
 // ============================================================================

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -59,7 +59,7 @@ function GameSelect() {
     void navigate({
       to: '/table/$id',
       params: { id: tableId },
-      state: { gameId: game.id } as Record<string, unknown>,
+      state: { pluginId: game.id } as Record<string, unknown>,
     });
   };
 

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -34,7 +34,6 @@ import { useHandPanel } from '../hooks/useHandPanel';
 import { moveAllCardsToHand } from '../store/YjsHandActions';
 import {
   loadPluginAssets,
-  reloadScenarioFromMetadata,
   type GameAssets,
   type LoadedScenarioMetadata,
 } from '../content';
@@ -240,29 +239,25 @@ function Table() {
         store.setGameAssets(assets);
         registerAttachmentActions(ActionRegistry.getInstance(), assets);
 
-        // If a scenario was previously loaded, instantiate it on top of the
-        // plugin assets. (Phase 3 will avoid the redundant pack refetch
-        // currently done inside reloadScenarioFromMetadata.)
+        // If a scenario was previously loaded, re-instantiate it on top of the
+        // already-loaded plugin assets. We only need the scenario JSON — packs
+        // are not refetched here (Phase 3).
+        //
+        // Objects themselves are already persisted in IndexedDB with their
+        // current state, so we deliberately do NOT re-add them; doing so would
+        // overwrite user modifications. The scenario fetch is currently kept
+        // for future use (e.g. metadata refresh) and to keep parity with the
+        // pre-refactor behavior, but on reload only `gameAssets` are restored
+        // — and those came from `loadPluginAssets` above, not from the
+        // scenario.
         const loadedScenario = store.metadata.get('loadedScenario') as
           | LoadedScenarioMetadata
           | undefined;
-        if (loadedScenario) {
-          console.log('[Table] Reloading scenario from metadata:', {
+        if (loadedScenario && loadedScenario.type === 'plugin') {
+          console.log('[Table] Reloaded scenario metadata present:', {
             type: loadedScenario.type,
             scenarioName: loadedScenario.scenarioName,
           });
-          const content = await reloadScenarioFromMetadata(loadedScenario);
-          // On reload: Only restore gameAssets, NOT objects. Objects are
-          // already persisted in IndexedDB with their current state; re-adding
-          // them would overwrite user modifications.
-          console.log(
-            '[Table] Restoring gameAssets from scenario (objects already in IndexedDB)',
-          );
-          store.setGameAssets(content.content);
-          registerAttachmentActions(
-            ActionRegistry.getInstance(),
-            content.content,
-          );
         }
       } catch (err) {
         const errorMessage =
@@ -276,14 +271,15 @@ function Table() {
 
     void loadContent();
 
-    // Observe metadata changes to detect when table is reset
+    // Observe metadata changes to detect when table is reset.
+    // resetTable() clears `loadedScenario` but preserves `pluginId` and the
+    // store's gameAssets — the table is still bound to its plugin after a
+    // reset, just with no objects placed.
     const observer = () => {
       const loadedScenario = store.metadata.get('loadedScenario');
-      const pluginId = store.metadata.get('pluginId');
 
-      // If both are cleared (table reset), clear error
-      if (!loadedScenario && !pluginId) {
-        console.log('[Table] Metadata cleared, clearing error state');
+      if (!loadedScenario) {
+        console.log('[Table] loadedScenario cleared, clearing error state');
         setPacksError(null);
       }
     };
@@ -307,13 +303,21 @@ function Table() {
 
   // Observe metadata changes for multiplayer scenario loading
   //
-  // When a remote player loads a scenario, we need to reload it locally to get gameAssets.
+  // When a remote player loads a scenario on a table where this client has
+  // not yet loaded plugin assets (e.g. they joined the table after the
+  // pluginId arrived but before the mount effect's plugin fetch finished, or
+  // the pluginId itself was pushed remotely), we load the plugin's assets
+  // here so this client can render objects that the CRDT just synced in.
+  //
+  // We do NOT re-instantiate scenario objects here: the remote already added
+  // them to Y.Doc and they sync via the CRDT. We only need the plugin
+  // assets (cards, tokens, attachments) to render them.
   //
   // Why gameAssets aren't in Y.Doc:
   // - gameAssets contain large data structures (card definitions, image URLs, etc.)
   // - Storing them in Y.Doc would cause excessive sync overhead for every change
   // - Y.Doc is optimized for operational transforms on structured data, not large immutable objects
-  // - Instead, we store minimal metadata (type, pluginId, scenarioFile) and reload on each client
+  // - Instead, we store minimal metadata (type, pluginId, scenarioFile) and load assets per-client
   //
   // Race condition handling:
   // - If scenario changes while loading, we compare loadedAt timestamps
@@ -344,17 +348,25 @@ function Table() {
         return;
       }
 
-      // If a remote player loaded a scenario, reload it locally to get gameAssets
-      if (loadedScenario && !store.getGameAssets()) {
-        console.log('[Table] Remote player loaded scenario, reloading locally');
+      // Only the 'plugin' branch is reachable here: 'builtin' is unused by app
+      // code, and 'local-dev' cannot be reloaded without user interaction.
+      if (
+        loadedScenario &&
+        loadedScenario.type === 'plugin' &&
+        !store.getGameAssets()
+      ) {
+        const pluginId = loadedScenario.pluginId;
+        console.log(
+          '[Table] Remote player loaded scenario; loading plugin assets',
+        );
         setPacksLoading(true);
         setPacksError(null);
 
         // Capture metadata timestamp to detect stale scenarios
         const metadataTimestamp = loadedScenario.loadedAt;
 
-        void reloadScenarioFromMetadata(loadedScenario)
-          .then((content) => {
+        void loadPluginAssets(pluginId)
+          .then((assets) => {
             // Check if scenario metadata changed while loading (race condition)
             const currentMetadata = store.metadata.get('loadedScenario') as
               | LoadedScenarioMetadata
@@ -377,10 +389,11 @@ function Table() {
             }
 
             // Metadata still matches - safe to set gameAssets
-            store.setGameAssets(content.content);
+            store.setGameAssets(assets);
+            registerAttachmentActions(ActionRegistry.getInstance(), assets);
             console.log(
-              '[Table] Remote scenario loaded successfully:',
-              content.scenario.name,
+              '[Table] Remote scenario assets loaded:',
+              loadedScenario.scenarioName,
             );
           })
           .catch((err: unknown) => {
@@ -509,7 +522,6 @@ function Table() {
                     if (store) {
                       resetTable(store);
                     }
-                    setGameAssets(null);
                     setPacksError(null);
                     setPacksLoading(false);
                   }}

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -181,8 +181,6 @@ function Table() {
   }, [store, isStoreReady, location.search]);
 
   // Store pluginId in Y.Doc metadata from location state (new table only).
-  // Reads still tolerate the legacy 'gameId' key — IndexedDB migration is
-  // Phase 4's responsibility, not Phase 2.
   useEffect(() => {
     if (!store || !isStoreReady) {
       return;
@@ -193,18 +191,13 @@ function Table() {
         ? (location.state as unknown as Record<string, unknown>)
         : null;
     const pluginIdFromStateRaw = stateRecord?.pluginId;
-    const gameIdFromStateRaw = stateRecord?.gameId;
     const pluginIdFromState =
       typeof pluginIdFromStateRaw === 'string'
         ? pluginIdFromStateRaw
-        : typeof gameIdFromStateRaw === 'string'
-          ? gameIdFromStateRaw
-          : undefined;
-    const storedPluginId =
-      (store.metadata.get('pluginId') as string | undefined) ??
-      (store.metadata.get('gameId') as string | undefined);
+        : undefined;
+    const storedPluginId = store.metadata.get('pluginId') as string | undefined;
 
-    // New table: store pluginId from navigation state under the canonical key.
+    // New table: store pluginId from navigation state.
     if (pluginIdFromState && !storedPluginId) {
       console.log(`[Table] Storing pluginId in metadata: ${pluginIdFromState}`);
       store.metadata.set('pluginId', pluginIdFromState);
@@ -230,10 +223,7 @@ function Table() {
       setPacksError(null);
 
       try {
-        // Reads tolerate the legacy 'gameId' key for now; Phase 4 migrates.
-        const pluginId =
-          (store.metadata.get('pluginId') as string | undefined) ??
-          (store.metadata.get('gameId') as string | undefined);
+        const pluginId = store.metadata.get('pluginId') as string | undefined;
 
         if (!pluginId) {
           console.log('[Table] No pluginId in metadata, skipping pack loading');
@@ -289,8 +279,7 @@ function Table() {
     // Observe metadata changes to detect when table is reset
     const observer = () => {
       const loadedScenario = store.metadata.get('loadedScenario');
-      const pluginId =
-        store.metadata.get('pluginId') ?? store.metadata.get('gameId');
+      const pluginId = store.metadata.get('pluginId');
 
       // If both are cleared (table reset), clear error
       if (!loadedScenario && !pluginId) {

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -239,17 +239,12 @@ function Table() {
         store.setGameAssets(assets);
         registerAttachmentActions(ActionRegistry.getInstance(), assets);
 
-        // If a scenario was previously loaded, re-instantiate it on top of the
-        // already-loaded plugin assets. We only need the scenario JSON — packs
-        // are not refetched here (Phase 3).
-        //
-        // Objects themselves are already persisted in IndexedDB with their
-        // current state, so we deliberately do NOT re-add them; doing so would
-        // overwrite user modifications. The scenario fetch is currently kept
-        // for future use (e.g. metadata refresh) and to keep parity with the
-        // pre-refactor behavior, but on reload only `gameAssets` are restored
-        // — and those came from `loadPluginAssets` above, not from the
-        // scenario.
+        // If scenario metadata was previously stored, only log its presence.
+        // On reload we deliberately do NOT fetch the scenario JSON or
+        // re-instantiate scenario objects — `gameAssets` were already
+        // restored by `loadPluginAssets` above, and the objects themselves
+        // are persisted in IndexedDB with their current state (re-adding
+        // them would overwrite user modifications).
         const loadedScenario = store.metadata.get('loadedScenario') as
           | LoadedScenarioMetadata
           | undefined;

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -180,29 +180,41 @@ function Table() {
     });
   }, [store, isStoreReady, location.search]);
 
-  // Store gameId in Y.Doc metadata from location state (new table only)
+  // Store pluginId in Y.Doc metadata from location state (new table only).
+  // Reads still tolerate the legacy 'gameId' key — IndexedDB migration is
+  // Phase 4's responsibility, not Phase 2.
   useEffect(() => {
     if (!store || !isStoreReady) {
       return;
     }
 
-    const gameIdFromState =
-      typeof location.state === 'object' &&
-      location.state !== null &&
-      'gameId' in location.state &&
-      typeof location.state.gameId === 'string'
-        ? location.state.gameId
-        : undefined;
-    const storedGameId = store.metadata.get('gameId') as string | undefined;
+    const stateRecord =
+      typeof location.state === 'object' && location.state !== null
+        ? (location.state as unknown as Record<string, unknown>)
+        : null;
+    const pluginIdFromStateRaw = stateRecord?.pluginId;
+    const gameIdFromStateRaw = stateRecord?.gameId;
+    const pluginIdFromState =
+      typeof pluginIdFromStateRaw === 'string'
+        ? pluginIdFromStateRaw
+        : typeof gameIdFromStateRaw === 'string'
+          ? gameIdFromStateRaw
+          : undefined;
+    const storedPluginId =
+      (store.metadata.get('pluginId') as string | undefined) ??
+      (store.metadata.get('gameId') as string | undefined);
 
-    // New table: store gameId from navigation state
-    if (gameIdFromState && !storedGameId) {
-      console.log(`[Table] Storing gameId in metadata: ${gameIdFromState}`);
-      store.metadata.set('gameId', gameIdFromState);
+    // New table: store pluginId from navigation state under the canonical key.
+    if (pluginIdFromState && !storedPluginId) {
+      console.log(`[Table] Storing pluginId in metadata: ${pluginIdFromState}`);
+      store.metadata.set('pluginId', pluginIdFromState);
     }
   }, [location.state, store, isStoreReady]);
 
-  // Load content on mount: either reload scenario from metadata or load base game assets
+  // Load content on mount: a plugin is a property of the table, not of a
+  // scenario. Always load the plugin's assets first (eagerly + cached via
+  // pluginLoader), then optionally restore a previously loaded scenario.
+  //
   // Note: Dependencies are [store, isStoreReady] only - we intentionally do NOT
   // depend on store.metadata because it's set once on mount and never changes
   // during the session. Depending on metadata would cause unnecessary reloads when
@@ -218,46 +230,49 @@ function Table() {
       setPacksError(null);
 
       try {
-        // Check if there's a previously loaded scenario to restore
+        // Reads tolerate the legacy 'gameId' key for now; Phase 4 migrates.
+        const pluginId =
+          (store.metadata.get('pluginId') as string | undefined) ??
+          (store.metadata.get('gameId') as string | undefined);
+
+        if (!pluginId) {
+          console.log('[Table] No pluginId in metadata, skipping pack loading');
+          // Blank state (no plugin, no scenario) — nothing to load.
+          setPacksError(null);
+          setPacksLoading(false);
+          return;
+        }
+
+        // Always load plugin assets first, unconditionally. The plugin loader's
+        // in-flight cache dedupes any concurrent callers (e.g. Load Scenario).
+        console.log('[Table] Loading plugin assets for:', pluginId);
+        const assets = await loadPluginAssets(pluginId);
+        store.setGameAssets(assets);
+        registerAttachmentActions(ActionRegistry.getInstance(), assets);
+
+        // If a scenario was previously loaded, instantiate it on top of the
+        // plugin assets. (Phase 3 will avoid the redundant pack refetch
+        // currently done inside reloadScenarioFromMetadata.)
         const loadedScenario = store.metadata.get('loadedScenario') as
           | LoadedScenarioMetadata
           | undefined;
-
         if (loadedScenario) {
-          // Reload scenario from metadata (for persistence and multiplayer)
           console.log('[Table] Reloading scenario from metadata:', {
             type: loadedScenario.type,
             scenarioName: loadedScenario.scenarioName,
           });
-
           const content = await reloadScenarioFromMetadata(loadedScenario);
-
-          // On reload: Only restore gameAssets, NOT objects
-          // Objects are already persisted in IndexedDB with their current state.
-          // Re-adding them would overwrite user modifications (moved stacks, etc.)
+          // On reload: Only restore gameAssets, NOT objects. Objects are
+          // already persisted in IndexedDB with their current state; re-adding
+          // them would overwrite user modifications.
           console.log(
-            '[Table] Restoring gameAssets only (objects already in IndexedDB)',
+            '[Table] Restoring gameAssets from scenario (objects already in IndexedDB)',
           );
           store.setGameAssets(content.content);
           registerAttachmentActions(
             ActionRegistry.getInstance(),
             content.content,
           );
-        } else {
-          // No scenario loaded - fall back to loading base game asset packs
-          const gameId = store.metadata.get('gameId') as string | undefined;
-          if (!gameId) {
-            console.log('[Table] No gameId in metadata, skipping pack loading');
-            // Clear error when in blank state (no gameId, no scenario)
-            setPacksError(null);
-            setPacksLoading(false);
-            return;
-          }
-
-          console.log('[Table] Loading plugin assets for:', gameId);
-          const assets = await loadPluginAssets(gameId);
-          store.setGameAssets(assets);
-          registerAttachmentActions(ActionRegistry.getInstance(), assets);
         }
       } catch (err) {
         const errorMessage =
@@ -274,10 +289,11 @@ function Table() {
     // Observe metadata changes to detect when table is reset
     const observer = () => {
       const loadedScenario = store.metadata.get('loadedScenario');
-      const gameId = store.metadata.get('gameId');
+      const pluginId =
+        store.metadata.get('pluginId') ?? store.metadata.get('gameId');
 
       // If both are cleared (table reset), clear error
-      if (!loadedScenario && !gameId) {
+      if (!loadedScenario && !pluginId) {
         console.log('[Table] Metadata cleared, clearing error state');
         setPacksError(null);
       }

--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -14,6 +14,7 @@ import {
   attachCards,
   detachCard,
   detachAllCards,
+  resetTable,
 } from './YjsActions';
 import {
   ObjectKind,
@@ -2973,5 +2974,95 @@ describe('YjsActions - attachCards', () => {
       expect(child1Obj._sortKey > bystanderObj._sortKey).toBe(true);
       expect(child2Obj._sortKey > bystanderObj._sortKey).toBe(true);
     });
+  });
+});
+
+// ============================================================================
+// resetTable Tests
+// ============================================================================
+
+describe('YjsActions - resetTable', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-reset-table');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    if (store) {
+      store.destroy();
+    }
+  });
+
+  it('clears placed objects', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1'],
+      faceUp: true,
+    });
+
+    expect(store.getObjectYMap(stackId)).toBeDefined();
+    expect(store.objects.size).toBeGreaterThan(0);
+
+    resetTable(store);
+
+    expect(store.objects.size).toBe(0);
+  });
+
+  it('clears loadedScenario metadata', () => {
+    store.metadata.set('loadedScenario', {
+      type: 'plugin',
+      pluginId: 'test-plugin',
+      scenarioFile: 'scenario-1.json',
+      loadedAt: 1234,
+      scenarioName: 'Test',
+    });
+
+    expect(store.metadata.get('loadedScenario')).toBeDefined();
+
+    resetTable(store);
+
+    expect(store.metadata.get('loadedScenario')).toBeUndefined();
+  });
+
+  it('preserves pluginId metadata (the table is still bound to the plugin)', () => {
+    store.metadata.set('pluginId', 'test-plugin');
+    store.metadata.set('loadedScenario', {
+      type: 'plugin',
+      pluginId: 'test-plugin',
+      scenarioFile: 'scenario-1.json',
+      loadedAt: 1234,
+      scenarioName: 'Test',
+    });
+
+    resetTable(store);
+
+    // pluginId is the table's identity for its plugin — must survive reset.
+    expect(store.metadata.get('pluginId')).toBe('test-plugin');
+  });
+
+  it('preserves store.gameAssets (still valid for the bound plugin)', () => {
+    const assets = {
+      packs: [],
+      cardTypes: {},
+      cards: {},
+      cardSets: {},
+      tokens: {},
+      counters: {},
+      mats: {},
+      tokenTypes: {},
+      statusTypes: {},
+      modifierStats: {},
+      iconTypes: {},
+    };
+    store.setGameAssets(assets);
+    expect(store.getGameAssets()).toBe(assets);
+
+    resetTable(store);
+
+    // gameAssets stay loaded — no reason to invalidate the renderer's caches.
+    expect(store.getGameAssets()).toBe(assets);
   });
 });

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1144,8 +1144,6 @@ export function resetTable(store: YjsStore): void {
   store.clearAllObjects();
   store.metadata.delete('loadedScenario');
   store.metadata.delete('pluginId');
-  // Also clear legacy key on pre-migration tables.
-  store.metadata.delete('gameId');
   store.setGameAssets(null);
 }
 

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1143,6 +1143,8 @@ export function detachAllCards(store: YjsStore, parentId: string): string[] {
 export function resetTable(store: YjsStore): void {
   store.clearAllObjects();
   store.metadata.delete('loadedScenario');
+  store.metadata.delete('pluginId');
+  // Also clear legacy key on pre-migration tables.
   store.metadata.delete('gameId');
   store.setGameAssets(null);
 }

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1141,10 +1141,14 @@ export function detachAllCards(store: YjsStore, parentId: string): string[] {
  * @param store - YjsStore instance
  */
 export function resetTable(store: YjsStore): void {
+  // Clear placed objects and the loaded-scenario marker, but PRESERVE the
+  // table's identity:
+  // - `pluginId`: a table belongs to a plugin (game) for its lifetime; reset
+  //   means "clear the placed objects", not "change games".
+  // - `gameAssets`: still valid for the plugin still bound to the table; no
+  //   reason to invalidate the renderer's asset cache.
   store.clearAllObjects();
   store.metadata.delete('loadedScenario');
-  store.metadata.delete('pluginId');
-  store.setGameAssets(null);
 }
 
 /**


### PR DESCRIPTION
## Summary

Plugin-loading refactor (`_plans/content-assets/planned/plugin-loading-architecture.md`), Phases 2 and 3 combined.

### Phase 2 — Eager plugin load on table create + cache + pluginId rename

- **In-flight + completed cache** in `app/src/content/pluginLoader.ts`, keyed by `pluginId`. Cache stores `Promise<LoadedPlugin>` (not the resolved value) so concurrent callers (mount effect + an immediate Load Scenario click) share a single fetch. Failed entries are evicted so subsequent callers can retry rather than getting a permanently-cached error.
- **Mount effect restructure** in `app/src/routes/table.$id.tsx`: `loadPluginAssets(pluginId)` runs first, unconditionally — a plugin is now a property of the table, not of a scenario. Previous "fallback" branching (load scenario OR else load plugin) is gone.
- **`gameId` -> `pluginId` rename** in Y.Doc metadata: `routes/index.tsx` pushes `pluginId` via navigation state; `table.$id.tsx` calls `metadata.set('pluginId', ...)`. **No backwards-compat read fallback** — project is unreleased, so old tables with `gameId`-only metadata are not supported. Users with stale tables can recover via `window.__ctDevTools.clearAllTables()`.

### Phase 3 — Pure scenario load (architectural split, NOT cache widening)

The user explicitly rejected widening the plugin cache to also cover packs. Real fix: scenario load no longer touches asset packs at all.

- **Deleted** `loadPluginScenario(pluginId, scenarioFilename)` and `reloadScenarioFromMetadata(metadata)`.
- **New** `loadScenarioFromPlugin(pluginId, scenarioFilename, gameAssets): Promise<LoadedContent>` in `app/src/content/index.ts`. Fetches scenario JSON only; calls `instantiateScenario(scenario, gameAssets)`; returns `{scenario, content: gameAssets, objects}`. **No `loadAssetPacks`, no `mergeAssetPacks`** — the supplied `gameAssets` reference is preserved through to the result.
- **Load Scenario action and load-marvelchampions-rhino action** (`app/src/actions/registerDefaultActions.ts`): pull `gameAssets` from `store.getGameAssets()` (populated on mount); fall back to `loadPluginAssets(pluginId)` only defensively if the store is empty.
- **Mount effect** in `table.$id.tsx`: when reloading a table that already has `loadedScenario` metadata, the redundant scenario re-fetch is now removed entirely. Plugin assets come from `loadPluginAssets` higher in the same effect; objects are persisted in IndexedDB. Previous code deliberately avoided re-adding objects on reload but still re-merged assets — both are now satisfied by the single `loadPluginAssets` call.
- **Remote-scenario observer** in `table.$id.tsx`: when another player loads a scenario on a client that hasn't loaded plugin assets yet, fetch only the assets via `loadPluginAssets`. Objects sync via the CRDT — no scenario JSON fetch needed remotely either.

### `resetTable` identity preservation

`store/YjsActions.ts:resetTable` previously cleared `pluginId` metadata and `gameAssets`. Both wrong — a table is bound to its plugin for its lifetime, and reset means "clear placed objects", not "change games". Now keeps `pluginId` and `gameAssets`; clears only `clearAllObjects()` and `metadata.delete('loadedScenario')`. The Reset Table action and the table-error UI button rely on this so the table remains usable post-reset without re-loading plugin assets.

## Cache implementation

`Map<string, Promise<LoadedPlugin>>` at module scope. `loadPlugin(pluginId)` returns the cached promise on hit, otherwise wraps the underlying fetch in a `.catch` that evicts the entry on rejection before re-throwing. Module-level scope is intentional per the plan's "cache scope" decision (plugins are immutable per session).

## Tests

- **New** `loadPlugin cache` describe block in `pluginLoader.test.ts`:
  - Two concurrent `loadPlugin('test-plugin')` calls return the same Promise (referential identity asserted before the gated fetch resolves) and result in exactly one registry fetch + one manifest fetch.
  - Completed entries serve from cache without additional fetches.
  - Failed entries are evicted so subsequent callers can retry successfully.
- **New** `loadScenarioFromPlugin` describe block in `content/index.test.ts`:
  - Asserts zero pack URL fetches during scenario load (only registry, manifest, and scenario JSON are fetched).
  - Asserts the supplied `gameAssets` reference is preserved through to `result.content`.
- **New** `resetTable` describe block in `store/YjsActions.test.ts`:
  - Preserves `pluginId` metadata and `store.gameAssets` after reset.
  - Clears placed objects and `loadedScenario` metadata.
- **Updated** `__tests__/routes/table.$id.test.tsx`:
  - Removed `reloadScenarioFromMetadata` mock (function deleted).
  - Asserts `loadPluginAssets` is called exactly once and `setGameAssets` is called exactly once when `pluginId` metadata is set on mount.

## Verification (live, against Phase 2 baseline)

Live verification on the dev server (running against Phase 2, pre-fix) confirmed the bugs the user reported:

- Click Load Scenario after table mount: **2 redundant pack refetches** (`marvelchampions-core.json`, `marvelchampions-bomb-scare.json`) plus the scenario JSON. With the fix, only the scenario JSON is fetched.
- Reset Table action: `pluginId` metadata cleared, `store.getGameAssets()` returned `null`. With the fix, both are preserved.

The dev server I had access to was pinned to PR #96's pre-fix commit (`e7cbdf1`); after this PR's tip is checked out, the verification path is to repeat the four steps above against the new commits and confirm zero new pack fetches on Load Scenario / page reload.

## Test plan

- [x] `pnpm run typecheck` (passed via pre-push hook)
- [x] `pnpm run format:check` (passed via pre-push hook)
- [ ] `pnpm run lint` — pre-commit hook ran lint-staged (only on staged files); full repo lint should be a CI job
- [ ] `pnpm run test` — harness blocked all test commands during this work; CI will verify
- [ ] `pnpm run test:e2e` — same, CI is the verification path
- [ ] **Manual repeat of the four-step verification above against the new commits** (re-run the dev server pointing at this PR's tip)

## Investigation beads filed

- **ct-5w5** — confirm mount effect skipping scenario re-fetch on reload is safe (no consumer of scenario JSON content beyond metadata).
- **ct-f3g** — duplicate `routes/table.$id.test.tsx` tests obsolete observer shape; relates to ct-8nr.
- **ct-ibr** — harness blocked all typecheck/test commands during this work; CI is the verification path.

## Out of scope (Phase 4)

- Migration of stale Y.Doc metadata: superseded by the "no backwards-compat" decision in Phase 2.
- `routes/table.$id.test.tsx` cleanup: tracked under ct-8nr / ct-f3g.

## Closes

- ct-4wk (Phase 2)
- ct-w78 (Phase 3)