### PR TITLE
Fix: multiplayer join with late pluginId loads gameAssets (ct-c69)

### DIFF
--- a/app/e2e/multiplayer-join.spec.ts
+++ b/app/e2e/multiplayer-join.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * E2E test for ct-c69: multiplayer JOIN with late `pluginId` arrival.
+ *
+ * Scenario this protects against:
+ *   - Player A creates a fresh table at /table/<uuid>; navigation state
+ *     carries `pluginId` and the route writes it to `store.metadata`.
+ *     Player A does NOT load a scenario (so `loadedScenario` is never set).
+ *   - Player B opens the SAME table URL with empty IndexedDB. The mount
+ *     effect at `isStoreReady` early-returns (no `pluginId` cached locally),
+ *     then the WebSocket sync delivers the `pluginId` written by A. Without
+ *     the fix in `table.$id.tsx`, the metadata observer would only react to
+ *     `loadedScenario` changes, so B's `gameAssets` would stay null forever.
+ *
+ * Two browser contexts share the same WebSocket-backed Y.Doc but have
+ * independent IndexedDB stores — exactly the multi-client shape that the
+ * single-context fixture cannot exercise.
+ *
+ * Determinism: the bug is timing-sensitive on a real network. To make the
+ * test reliably exercise the buggy code path, we open Player B FIRST and
+ * wait for B's `waitForReady()` (which resolves on IndexedDB-synced) to
+ * complete BEFORE Player A writes `pluginId`. That guarantees B's mount
+ * effect runs with no `pluginId` available and early-returns; the only
+ * recovery path is the metadata observer reacting to A's later remote
+ * write.
+ */
+
+import { test, expect } from './_fixtures';
+import type { GameAssets } from '@cardtable2/shared';
+
+interface MetadataMap {
+  set: (key: string, value: unknown) => void;
+  get: (key: string) => unknown;
+}
+
+interface JoinTestStore {
+  metadata: MetadataMap;
+  getGameAssets: () => GameAssets | null;
+  waitForReady: () => Promise<void>;
+}
+
+interface JoinTestGlobalThis {
+  __TEST_STORE__?: JoinTestStore;
+}
+
+test.describe('Multiplayer JOIN with late pluginId (ct-c69)', () => {
+  test('joining client loads gameAssets when remote pluginId arrives after mount', async ({
+    browser,
+  }, testInfo) => {
+    // Unique table id per test EXECUTION keeps us isolated even when the
+    // dev y-websocket server retains state across runs of the same test
+    // (testInfo.testId is hash-deterministic, so without `Date.now()` the
+    // server state from a prior pass would leak into this one).
+    const tableId = `mp-join-${testInfo.testId.replace(/[^a-z0-9]/gi, '-')}-${Date.now()}`;
+
+    // ---------- Player B: joiner, opens FIRST with empty IndexedDB ----------
+    // Opening B first guarantees its mount effect runs with no `pluginId`
+    // available locally — exactly the bug's preconditions.
+    const ctxB = await browser.newContext();
+    const pageB = await ctxB.newPage();
+    await pageB.goto(`/table/${tableId}`);
+
+    await pageB.waitForFunction(() =>
+      Boolean((globalThis as unknown as JoinTestGlobalThis).__TEST_STORE__),
+    );
+    await pageB.evaluate(async () => {
+      const store = (globalThis as unknown as JoinTestGlobalThis)
+        .__TEST_STORE__;
+      await store?.waitForReady();
+    });
+
+    // Sanity: B's metadata is empty at mount time.
+    const bPluginIdAtMount = await pageB.evaluate(() => {
+      const store = (globalThis as unknown as JoinTestGlobalThis)
+        .__TEST_STORE__;
+      return store?.metadata.get('pluginId');
+    });
+    expect(bPluginIdAtMount).toBeUndefined();
+
+    // ---------- Player A: creator, writes pluginId AFTER B is mounted ------
+    // Simulates "player A picked a game on the home screen" by writing
+    // `pluginId` directly to metadata. This is the same write the
+    // pluginId-storage effect in `table.$id.tsx` performs on a fresh table
+    // navigation. We do NOT load a scenario — the bug's hot path is when a
+    // remote client writes only `pluginId`.
+    const ctxA = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    await pageA.goto(`/table/${tableId}`);
+
+    await pageA.waitForFunction(() =>
+      Boolean((globalThis as unknown as JoinTestGlobalThis).__TEST_STORE__),
+    );
+    await pageA.evaluate(async () => {
+      const store = (globalThis as unknown as JoinTestGlobalThis)
+        .__TEST_STORE__;
+      await store?.waitForReady();
+    });
+
+    await pageA.evaluate((pluginId) => {
+      const store = (globalThis as unknown as JoinTestGlobalThis)
+        .__TEST_STORE__;
+      if (!store) throw new Error('Player A: __TEST_STORE__ not exposed');
+      store.metadata.set('pluginId', pluginId);
+    }, 'testgame');
+
+    // Within a reasonable timeout, B must observe the remote `pluginId`
+    // write and populate gameAssets via the metadata observer.
+    await pageB.waitForFunction(
+      () => {
+        const store = (globalThis as unknown as JoinTestGlobalThis)
+          .__TEST_STORE__;
+        if (!store) return false;
+        return store.getGameAssets() !== null;
+      },
+      undefined,
+      { timeout: 10_000 },
+    );
+
+    // Belt-and-braces: B sees the synced pluginId. Protects against a
+    // future regression where assets get loaded but metadata doesn't sync.
+    const bPluginIdAfter = await pageB.evaluate(() => {
+      const store = (globalThis as unknown as JoinTestGlobalThis)
+        .__TEST_STORE__;
+      return store?.metadata.get('pluginId');
+    });
+    expect(bPluginIdAfter).toBe('testgame');
+
+    await ctxA.close();
+    await ctxB.close();
+  });
+});

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -24,12 +24,23 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'pnpm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    env: {
-      VITE_E2E: 'true', // Disable antialias during E2E tests
+  // Start both the vite dev server (port 3000) and the y-websocket server
+  // (port 3001) so multi-context tests like e2e/multiplayer-join.spec.ts can
+  // synchronize across browser contexts. The Playwright cwd is `app/`, but
+  // pnpm `--filter` resolves workspaces from the monorepo root regardless.
+  webServer: [
+    {
+      command: 'pnpm --filter "@cardtable2/app" run dev',
+      url: 'http://localhost:3000',
+      reuseExistingServer: !process.env.CI,
+      env: {
+        VITE_E2E: 'true', // Disable antialias during E2E tests
+      },
     },
-  },
+    {
+      command: 'pnpm --filter "@cardtable2/server" run dev',
+      url: 'http://localhost:3001/health',
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });

--- a/app/src/routes/table.$id.test.tsx
+++ b/app/src/routes/table.$id.test.tsx
@@ -59,9 +59,16 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
     const setPacksError = mockSetPacksError as (...args: unknown[]) => void;
     const logSpy = consoleLogSpy as (...args: unknown[]) => void;
     const errorSpy = consoleErrorSpy as (...args: unknown[]) => void;
-    // This simulates the observer function from table.$id.tsx (lines 168-247)
+    // This simulates the observer function from table.$id.tsx — see the
+    // comment block on the metadata-observe useEffect for behavioural detail.
+    // Both the bare-pluginId path (multiplayer JOIN with empty IndexedDB) and
+    // the scenario-load path converge on the same loader; the test uses a
+    // single `reloadScenario` mock to stand in for `loadPluginAssets`.
     return (_event: unknown, transaction: { local: boolean }): void => {
       if (transaction.local) return;
+
+      // Already-loaded short-circuit
+      if (mockStore.getGameAssets()) return;
 
       const loadedScenario = mockStore.metadata.get('loadedScenario') as
         | LoadedScenarioMetadata
@@ -78,17 +85,41 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
         return;
       }
 
-      if (loadedScenario && !mockStore.getGameAssets()) {
-        logSpy('[Table] Remote player loaded scenario, reloading locally');
-        setPacksLoading(true);
-        setPacksError(null);
+      // Resolve pluginId + race-check policy from the available metadata.
+      let pluginId: string | undefined;
+      let metadataTimestamp: number | undefined;
+      let source: 'scenario' | 'pluginId';
 
-        const metadataTimestamp = loadedScenario.loadedAt;
+      if (loadedScenario && loadedScenario.type === 'plugin') {
+        pluginId = loadedScenario.pluginId;
+        metadataTimestamp = loadedScenario.loadedAt;
+        source = 'scenario';
+      } else if (!loadedScenario) {
+        const bare = mockStore.metadata.get('pluginId') as string | undefined;
+        if (bare) {
+          pluginId = bare;
+          source = 'pluginId';
+        } else {
+          return;
+        }
+      } else {
+        // builtin / local-dev — not handled here.
+        return;
+      }
 
-        void reloadScenario(loadedScenario)
-          .then((content: LoadedContent) => {
-            // Capture parameter types to ensure proper inference in nested callbacks
-            const log = logSpy;
+      if (!pluginId) return;
+
+      logSpy(
+        `[Table] Remote ${source === 'scenario' ? 'scenario load' : 'pluginId arrival'}; loading plugin assets`,
+        { pluginId, source },
+      );
+      setPacksLoading(true);
+      setPacksError(null);
+
+      void reloadScenario(loadedScenario ?? { pluginId, source })
+        .then((content: LoadedContent) => {
+          const log = logSpy;
+          if (source === 'scenario') {
             const currentMetadata = mockStore.metadata.get('loadedScenario') as
               | LoadedScenarioMetadata
               | undefined;
@@ -100,7 +131,10 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
               log(
                 '[Table] Scenario changed during load, discarding stale assets',
                 {
-                  loadedScenario: loadedScenario.scenarioName,
+                  loadedScenario:
+                    loadedScenario && loadedScenario.type === 'plugin'
+                      ? loadedScenario.scenarioName
+                      : undefined,
                   loadedAt: metadataTimestamp,
                   currentScenario: currentMetadata?.scenarioName,
                   currentLoadedAt: currentMetadata?.loadedAt,
@@ -108,36 +142,34 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
               );
               return;
             }
+          }
 
-            mockStore.setGameAssets(content.content);
-            log(
-              '[Table] Remote scenario loaded successfully:',
-              content.scenario.name,
-            );
-          })
-          .catch((err: unknown) => {
-            // Capture parameter types to ensure proper inference in nested callbacks
-            const error = errorSpy;
-            const setPacks = setPacksError;
-            const errorMessage =
-              err instanceof Error
-                ? err.message
-                : 'Failed to load remote scenario';
-            const errorObject =
-              err instanceof Error ? err : new Error(String(err));
-            error('[Table] Remote scenario loading error:', {
-              error: errorObject,
-              errorMessage,
-              metadata: loadedScenario,
-            });
-            setPacks(errorMessage);
-          })
-          .finally(() => {
-            // Capture parameter types to ensure proper inference in nested callbacks
-            const setLoading = setPacksLoading;
-            setLoading(false);
+          if (mockStore.getGameAssets()) return;
+          mockStore.setGameAssets(content.content);
+          log('[Table] Remote plugin assets loaded:', { pluginId, source });
+        })
+        .catch((err: unknown) => {
+          const error = errorSpy;
+          const setPacks = setPacksError;
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : 'Failed to load remote scenario';
+          const errorObject =
+            err instanceof Error ? err : new Error(String(err));
+          error('[Table] Remote plugin asset loading error:', {
+            error: errorObject,
+            errorMessage,
+            pluginId,
+            source,
+            metadata: loadedScenario,
           });
-      }
+          setPacks(errorMessage);
+        })
+        .finally(() => {
+          const setLoading = setPacksLoading;
+          setLoading(false);
+        });
     };
   };
 
@@ -257,7 +289,9 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
       expect(mockReloadScenario).toHaveBeenCalledWith(metadata);
     });
 
-    it('should accept valid builtin metadata', () => {
+    it('should ignore builtin metadata (not reachable in app code)', () => {
+      // The observer intentionally only handles `type: 'plugin'`. The
+      // 'builtin' branch is unused by app code (see source comment).
       const observer = createObserver();
       const metadata: LoadedScenarioMetadata = {
         type: 'builtin',
@@ -273,10 +307,13 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
 
       observer(null, { local: false });
 
-      expect(mockReloadScenario).toHaveBeenCalledWith(metadata);
+      expect(mockReloadScenario).not.toHaveBeenCalled();
+      expect(mockSetPacksLoading).not.toHaveBeenCalled();
     });
 
-    it('should accept valid local-dev metadata', () => {
+    it('should ignore local-dev metadata (not reloadable without user action)', () => {
+      // Same as above: 'local-dev' cannot be reloaded without user
+      // interaction, so the observer must not auto-load.
       const observer = createObserver();
       const metadata: LoadedScenarioMetadata = {
         type: 'local-dev',
@@ -291,7 +328,8 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
 
       observer(null, { local: false });
 
-      expect(mockReloadScenario).toHaveBeenCalledWith(metadata);
+      expect(mockReloadScenario).not.toHaveBeenCalled();
+      expect(mockSetPacksLoading).not.toHaveBeenCalled();
     });
   });
 
@@ -348,6 +386,132 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
       // Should start reload
       expect(mockSetPacksLoading).toHaveBeenCalledWith(true);
       expect(mockReloadScenario).toHaveBeenCalledWith(metadata);
+    });
+  });
+
+  // ct-c69: bare-pluginId arrival without a loadedScenario.
+  //
+  // Multiplayer JOIN scenario: Player A creates a fresh table for plugin X
+  // (writes only `pluginId` to metadata, no scenario). Player B opens the
+  // same URL with empty IndexedDB. B's mount effect early-returns (no
+  // pluginId at hydrate time), then WebSocket syncs the bare `pluginId` in
+  // remotely. Without the unified observer, B never loads plugin assets.
+  describe('bare pluginId path (multiplayer JOIN, ct-c69)', () => {
+    it('should load assets when only pluginId is present (no loadedScenario)', async () => {
+      const observer = createObserver();
+
+      // Simulate the metadata state after a remote bare-pluginId write:
+      // pluginId present, loadedScenario absent.
+      mockStore.metadata.set('pluginId', 'test-plugin');
+
+      const mockContent = createMockContent('Test Scenario');
+      mockReloadScenario.mockResolvedValue(mockContent);
+
+      observer(null, { local: false });
+
+      expect(mockSetPacksLoading).toHaveBeenCalledWith(true);
+
+      await vi.waitFor(() => {
+        expect(mockReloadScenario).toHaveBeenCalled();
+      });
+
+      await vi.waitFor(() => {
+        expect(mockStore.setGameAssets).toHaveBeenCalledWith(
+          mockContent.content,
+        );
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Table] Remote plugin assets loaded:',
+        expect.objectContaining({
+          pluginId: 'test-plugin',
+          source: 'pluginId',
+        }),
+      );
+    });
+
+    it('should skip the stale-load race-check on the bare-pluginId path', async () => {
+      const observer = createObserver();
+
+      mockStore.metadata.set('pluginId', 'test-plugin');
+
+      // If a scenario load lands during the bare-pluginId fetch, the bare
+      // path must NOT discard the asset just because loadedScenario appeared
+      // — there's no `loadedAt` to race against; pluginId is set-once.
+      const mockContent = createMockContent('Late Scenario');
+      mockReloadScenario.mockImplementation(() => {
+        const lateMeta: LoadedScenarioMetadata = {
+          type: 'plugin',
+          pluginId: 'test-plugin',
+          scenarioFile: 's.json',
+          loadedAt: 9999,
+          scenarioName: 'Late Scenario',
+        };
+        mockStore.metadata.set('loadedScenario', lateMeta);
+        return Promise.resolve(mockContent);
+      });
+
+      observer(null, { local: false });
+
+      await vi.waitFor(() => {
+        expect(mockReloadScenario).toHaveBeenCalled();
+      });
+
+      await vi.waitFor(() => {
+        expect(mockStore.setGameAssets).toHaveBeenCalledWith(
+          mockContent.content,
+        );
+      });
+
+      // No "discarding stale" log on the bare path.
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        '[Table] Scenario changed during load, discarding stale assets',
+        expect.anything(),
+      );
+    });
+
+    it('should noop when neither loadedScenario nor pluginId is present', () => {
+      const observer = createObserver();
+
+      // Empty metadata — neither key set.
+      observer(null, { local: false });
+
+      expect(mockReloadScenario).not.toHaveBeenCalled();
+      expect(mockSetPacksLoading).not.toHaveBeenCalled();
+    });
+
+    it('should prefer loadedScenario over bare pluginId when both are present', () => {
+      const observer = createObserver();
+      const scenario: LoadedScenarioMetadata = {
+        type: 'plugin',
+        pluginId: 'scenario-plugin',
+        scenarioFile: 'scenario1.json',
+        loadedAt: Date.now(),
+        scenarioName: 'Test Scenario',
+      };
+
+      mockStore.metadata.set('loadedScenario', scenario);
+      mockStore.metadata.set('pluginId', 'bare-plugin');
+      mockReloadScenario.mockResolvedValue(createMockContent('Test Scenario'));
+
+      observer(null, { local: false });
+
+      // Scenario path is taken — note 'scenario-plugin', not 'bare-plugin'.
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('scenario load'),
+        expect.objectContaining({ pluginId: 'scenario-plugin' }),
+      );
+    });
+
+    it('should skip when pluginId is empty string', () => {
+      const observer = createObserver();
+
+      mockStore.metadata.set('pluginId', '');
+
+      observer(null, { local: false });
+
+      expect(mockReloadScenario).not.toHaveBeenCalled();
+      expect(mockSetPacksLoading).not.toHaveBeenCalled();
     });
   });
 
@@ -430,8 +594,11 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
       });
 
       expect(consoleLogSpy).toHaveBeenCalledWith(
-        '[Table] Remote scenario loaded successfully:',
-        'Test Scenario',
+        '[Table] Remote plugin assets loaded:',
+        expect.objectContaining({
+          pluginId: 'test-plugin',
+          source: 'scenario',
+        }),
       );
     });
 
@@ -494,11 +661,13 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
 
       await vi.waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[Table] Remote scenario loading error:',
+          '[Table] Remote plugin asset loading error:',
           expect.objectContaining({
             error: testError,
             errorMessage: 'Network failure',
             metadata,
+            pluginId: 'test-plugin',
+            source: 'scenario',
           }),
         );
       });
@@ -527,10 +696,12 @@ describe('table.$id.tsx - Multiplayer Observer', () => {
 
       await vi.waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          '[Table] Remote scenario loading error:',
+          '[Table] Remote plugin asset loading error:',
           expect.objectContaining({
             errorMessage: 'Failed to load remote scenario',
             metadata,
+            pluginId: 'test-plugin',
+            source: 'scenario',
           }),
         );
       });

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -296,13 +296,28 @@ function Table() {
     return unsubscribe;
   }, [store]);
 
-  // Observe metadata changes for multiplayer scenario loading
+  // Observe metadata changes for multiplayer asset loading.
   //
-  // When a remote player loads a scenario on a table where this client has
-  // not yet loaded plugin assets (e.g. they joined the table after the
-  // pluginId arrived but before the mount effect's plugin fetch finished, or
-  // the pluginId itself was pushed remotely), we load the plugin's assets
-  // here so this client can render objects that the CRDT just synced in.
+  // Two remote-driven paths reach here:
+  //
+  // 1. Bare-pluginId arrival (multiplayer JOIN). Player A creates a fresh
+  //    table and writes `pluginId` to metadata; Player B joins the same URL
+  //    with empty IndexedDB. B's mount effect runs at `isStoreReady` and sees
+  //    no `pluginId` (IndexedDB had nothing to hydrate); the WebSocket then
+  //    syncs `pluginId` in afterwards. Without this observer reacting to the
+  //    bare `pluginId` write, B's `gameAssets` would stay null and any
+  //    CRDT-synced objects would render without their plugin assets.
+  //
+  // 2. Remote scenario load. Another player loads a scenario; we need plugin
+  //    assets locally to render the objects that the CRDT just synced in.
+  //    `loadedScenario.pluginId` is authoritative for which plugin to load,
+  //    and the `loadedAt` timestamp guards against a stale-load race when the
+  //    scenario changes mid-fetch.
+  //
+  // Both paths converge on the same load primitive (`loadPluginAssets`). The
+  // pluginLoader's in-flight cache dedupes concurrent calls, so there's no
+  // harm if both an early `pluginId` and a later `loadedScenario` arrive in
+  // separate transactions for the same plugin.
   //
   // We do NOT re-instantiate scenario objects here: the remote already added
   // them to Y.Doc and they sync via the CRDT. We only need the plugin
@@ -313,10 +328,6 @@ function Table() {
   // - Storing them in Y.Doc would cause excessive sync overhead for every change
   // - Y.Doc is optimized for operational transforms on structured data, not large immutable objects
   // - Instead, we store minimal metadata (type, pluginId, scenarioFile) and load assets per-client
-  //
-  // Race condition handling:
-  // - If scenario changes while loading, we compare loadedAt timestamps
-  // - Stale gameAssets are discarded to prevent incorrect rendering
   useEffect(() => {
     if (!store || !isStoreReady) return;
 
@@ -327,11 +338,14 @@ function Table() {
       // Only react to remote changes (from other players)
       if (transaction.local) return;
 
+      // If we already have assets, nothing to do.
+      if (store.getGameAssets()) return;
+
       const loadedScenario = store.metadata.get('loadedScenario') as
         | LoadedScenarioMetadata
         | undefined;
 
-      // Validate metadata structure
+      // Validate scenario metadata structure when present.
       if (
         loadedScenario &&
         (typeof loadedScenario !== 'object' || !loadedScenario.type)
@@ -343,26 +357,51 @@ function Table() {
         return;
       }
 
-      // Only the 'plugin' branch is reachable here: 'builtin' is unused by app
-      // code, and 'local-dev' cannot be reloaded without user interaction.
-      if (
-        loadedScenario &&
-        loadedScenario.type === 'plugin' &&
-        !store.getGameAssets()
-      ) {
-        const pluginId = loadedScenario.pluginId;
-        console.log(
-          '[Table] Remote player loaded scenario; loading plugin assets',
-        );
-        setPacksLoading(true);
-        setPacksError(null);
+      // Resolve which pluginId to load and whether we need stale-load
+      // race-checking. Scenario path is authoritative when present (carries a
+      // `loadedAt` timestamp); bare-pluginId path is set-once-on-create so no
+      // race-check is required.
+      //
+      // Only the 'plugin' branch of `loadedScenario` is reachable in app code:
+      // 'builtin' is unused, and 'local-dev' cannot be reloaded without user
+      // interaction.
+      let pluginId: string | undefined;
+      let metadataTimestamp: number | undefined;
+      let source: 'scenario' | 'pluginId';
 
-        // Capture metadata timestamp to detect stale scenarios
-        const metadataTimestamp = loadedScenario.loadedAt;
+      if (loadedScenario && loadedScenario.type === 'plugin') {
+        pluginId = loadedScenario.pluginId;
+        metadataTimestamp = loadedScenario.loadedAt;
+        source = 'scenario';
+      } else if (!loadedScenario) {
+        const bare = store.metadata.get('pluginId') as string | undefined;
+        if (bare) {
+          pluginId = bare;
+          source = 'pluginId';
+        } else {
+          return;
+        }
+      } else {
+        // loadedScenario present but type !== 'plugin' (builtin/local-dev) —
+        // not handled by this observer.
+        return;
+      }
 
-        void loadPluginAssets(pluginId)
-          .then((assets) => {
-            // Check if scenario metadata changed while loading (race condition)
+      if (!pluginId) return;
+
+      console.log(
+        `[Table] Remote ${source === 'scenario' ? 'scenario load' : 'pluginId arrival'}; loading plugin assets`,
+        { pluginId, source },
+      );
+      setPacksLoading(true);
+      setPacksError(null);
+
+      void loadPluginAssets(pluginId)
+        .then((assets) => {
+          // Stale-load race-check applies only to scenario-driven loads,
+          // where the scenario can change mid-fetch. For bare-pluginId we
+          // skip the check (pluginId is set-once on table create).
+          if (source === 'scenario') {
             const currentMetadata = store.metadata.get('loadedScenario') as
               | LoadedScenarioMetadata
               | undefined;
@@ -374,7 +413,10 @@ function Table() {
               console.log(
                 '[Table] Scenario changed during load, discarding stale assets',
                 {
-                  loadedScenario: loadedScenario.scenarioName,
+                  loadedScenario:
+                    loadedScenario && loadedScenario.type === 'plugin'
+                      ? loadedScenario.scenarioName
+                      : undefined,
                   loadedAt: metadataTimestamp,
                   currentScenario: currentMetadata?.scenarioName,
                   currentLoadedAt: currentMetadata?.loadedAt,
@@ -382,33 +424,39 @@ function Table() {
               );
               return;
             }
+          }
 
-            // Metadata still matches - safe to set gameAssets
-            store.setGameAssets(assets);
-            registerAttachmentActions(ActionRegistry.getInstance(), assets);
-            console.log(
-              '[Table] Remote scenario assets loaded:',
-              loadedScenario.scenarioName,
-            );
-          })
-          .catch((err: unknown) => {
-            const errorMessage =
-              err instanceof Error
-                ? err.message
-                : 'Failed to load remote scenario';
-            const errorObject =
-              err instanceof Error ? err : new Error(String(err));
-            console.error('[Table] Remote scenario loading error:', {
-              error: errorObject,
-              errorMessage,
-              metadata: loadedScenario,
-            });
-            setPacksError(errorMessage);
-          })
-          .finally(() => {
-            setPacksLoading(false);
+          // If another path already populated assets while we were loading,
+          // skip — the in-flight cache made our promise cheap, but
+          // double-registering attachment actions is wasted work.
+          if (store.getGameAssets()) return;
+
+          store.setGameAssets(assets);
+          registerAttachmentActions(ActionRegistry.getInstance(), assets);
+          console.log('[Table] Remote plugin assets loaded:', {
+            pluginId,
+            source,
           });
-      }
+        })
+        .catch((err: unknown) => {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : 'Failed to load remote scenario';
+          const errorObject =
+            err instanceof Error ? err : new Error(String(err));
+          console.error('[Table] Remote plugin asset loading error:', {
+            error: errorObject,
+            errorMessage,
+            pluginId,
+            source,
+            metadata: loadedScenario,
+          });
+          setPacksError(errorMessage);
+        })
+        .finally(() => {
+          setPacksLoading(false);
+        });
     };
 
     store.metadata.observe(observer);


### PR DESCRIPTION
## Summary

- **Bug:** When Player B joins a table whose `pluginId` was written by Player A but no scenario has been loaded, B's IndexedDB is empty at mount, so the mount effect at `table.$id.tsx` early-returns. The metadata observer then needs to react when `pluginId` arrives via WebSocket sync, but the prior observer only fired its load path on `loadedScenario` changes — leaving B's `gameAssets` permanently null and any CRDT-synced objects unable to render plugin content.
- **Mechanism:** Three pieces of code touch `store.metadata` in `table.$id.tsx`. The pluginId-storage effect (~line 183) writes from `location.state` once; the mount effect (~line 215) reads `pluginId` once when `isStoreReady` and early-returns if undefined; the remote-scenario observer (~line 320) fired only when `loadedScenario` was set, never on a bare-`pluginId` arrival. `YjsStore.waitForReady()` waits for IndexedDB sync only, not WebSocket sync, so a remote-set `pluginId` reliably arrives AFTER the mount effect has already early-returned on a clean-IndexedDB join.
- **Fix (option a, unified observer):** Broadened the existing remote-metadata observer to resolve `pluginId` from `loadedScenario.pluginId` (preferred, with `loadedAt` race-check) OR `metadata.get('pluginId')` (fallback, no race-check needed because `pluginId` is set-once on table create). Both paths converge on `loadPluginAssets`, whose in-flight cache dedupes concurrent calls. Picked (a) over a parallel observer because it kept the load path single, and the pluginLoader's existing dedupe handles the only concern that justified parallel observers. No new flag threaded through layers; existing observer pattern extended (per project memory).

Reasoning verified by reading the file before changing it; the orchestrator's mechanism trace matched the source.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run format:check` — passes
- [x] `pnpm test` — all 1039 unit tests pass (existing 18 + 5 new bare-pluginId cases in `app/src/routes/table.$id.test.tsx`)
- [x] New E2E test `app/e2e/multiplayer-join.spec.ts` — Player B mounts first against empty doc, then Player A writes `pluginId`; B's `getGameAssets()` becomes non-null within 10s
- [x] Adjacent E2E suites (`plugin-loading.spec.ts`, `state-persistence.spec.ts`) still pass
- [x] Verified the new E2E test FAILS without the fix (timeout waiting for assets) and PASSES with the fix — confirms it actually catches the regression
- [ ] Manual smoke test: open `/` in two browsers, A picks Marvel Champions, both navigate to the same table URL — B should render with assets even when its IndexedDB is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)