### PR TITLE
test(e2e): bump card-preview-hover dismiss timeout to 2s (ct-uft)

### DIFF
--- a/app/e2e/card-preview-hover.spec.ts
+++ b/app/e2e/card-preview-hover.spec.ts
@@ -199,9 +199,23 @@ test.describe('Card Preview Hover - Dismiss Path (ct-zqc)', () => {
       buttons: 0,
     });
 
-    // Preview must dismiss. Allow up to 1s for the message round-trip
-    // (renderer -> postResponse -> Board.setHoveredObject -> setPreviewCard).
-    await expect(preview).not.toBeVisible({ timeout: 1000 });
+    // Preview must dismiss. The dismiss path is:
+    //   renderer.handlePointerMove (worker)
+    //   -> postResponse({ type: 'object-hovered', objectId: null })
+    //   -> Board.setHoveredObject(null)
+    //   -> setPreviewCard(null)
+    //   -> React re-render unmounts CardPreview
+    //
+    // Under the full E2E suite (workers=2 on CI, more locally), the worker
+    // thread, main thread, and React commit phase contend with other browser
+    // contexts, vite HMR housekeeping, and y-websocket dev-server traffic.
+    // The dismiss eventually wins, but not always within a tight 1s window
+    // (ct-uft observed a single full-suite failure where it took longer
+    // than 1s; isolated and follow-up CI runs were green). Match the 2s
+    // budget used by the appearance assertion above (line 125) for symmetry
+    // — both ends of the lifecycle are subject to the same scheduling
+    // pressure, so giving them the same headroom is the principled choice.
+    await expect(preview).not.toBeVisible({ timeout: 2000 });
 
     // No errors should have been thrown during the interaction.
     expect(errors).toEqual([]);


### PR DESCRIPTION
## Summary

Resolves **ct-uft** — Investigate: card-preview-hover.spec.ts flake under full E2E run.

During Phase 2 (ct-4wk) verification, `e2e/card-preview-hover.spec.ts` failed once under the full suite (98 passed, 1 failed) at the final dismiss assertion: `expect(preview).not.toBeVisible({ timeout: 1000 })`. Re-running ONLY that file passed, and follow-up CI runs were green.

Diagnosis: load-contention timing, not a logic regression.

The dismiss path is worker -> main postMessage -> React re-render. Under the full E2E suite the threads contend with other browser contexts, vite HMR, and y-websocket dev-server traffic; an isolated run of this spec averages 1.5s end-to-end, but the 1s budget on this single assertion left no headroom for a one-off scheduler stall.

This change bumps the timeout from 1000ms to 2000ms — matching the appearance assertion (line 125, `toBeVisible({ timeout: 2000 })`) above. Both ends of the preview lifecycle share the same scheduling pressure, so identical headroom is the principled fit. No production code changes; the underlying ct-zqc fix (28848bf) remains the actual mechanism that closes the original stuck-preview bug.

**Reproduction strategies tried, all green:**
- Isolated `--repeat-each=20` (CI=1): 20/20 pass
- Full suite at workers=2 (CI shape): 3/3 runs pass
- Full suite at workers=4: 3/3 runs pass
- Full suite at workers=8: 2/2 runs pass
- Recent CI run-log review: only an unrelated multiplayer-join failure; no recurring card-preview-hover failures

Could not reproduce after ~5 full-suite runs and 20+ isolated runs. The "load contention symptom" hypothesis from the bead description is the remaining diagnosis; bumping the dismiss timeout to match the appearance timeout is the minimum-surface-area defensive fix.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes (no new disabled rules)
- [x] `pnpm run format:check` passes
- [x] App unit tests pass (1039/1039)
- [x] Full E2E suite (`CI=1 pnpm exec playwright test`) passes
- [x] `card-preview-hover.spec.ts --repeat-each=20` passes
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)