### PR TITLE
Explicit error UI for stale plugin references (ct-f7f)

### DIFF
--- a/app/e2e/stale-plugin-error.spec.ts
+++ b/app/e2e/stale-plugin-error.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * E2E test for the stale-plugin error UI (ct-f7f).
+ *
+ * Setup: write a bogus `pluginId` into the table's Y.Doc metadata, reload the
+ * production `/table/:id` route, and assert the explicit "plugin no longer
+ * available" error UI renders with the missing pluginId named in the message
+ * and the action buttons present and functional.
+ *
+ * The auto-clear fixture only clears `objects` — `metadata` survives, so the
+ * pluginId we set persists across the reload that triggers the load path.
+ */
+
+import { test, expect } from './_fixtures';
+
+interface TestStoreWithMetadata {
+  metadata: {
+    set: (key: string, value: unknown) => void;
+    get: (key: string) => unknown;
+    delete: (key: string) => void;
+  };
+  waitForReady: () => Promise<void>;
+}
+
+interface TestGlobalThis {
+  __TEST_STORE__?: TestStoreWithMetadata;
+}
+
+const MISSING_PLUGIN_ID = 'nonexistent-plugin-foo';
+
+test.describe('Stale plugin error UI (ct-f7f)', () => {
+  test('renders explicit plugin-not-found UI when metadata references a missing plugin', async ({
+    page,
+  }, testInfo) => {
+    // Use the production /table/:id route — that's where users hit this case
+    // after their saved table's plugin disappears from pluginsIndex.json.
+    const tableId = `stale-${testInfo.testId.replace(/[^a-z0-9]/gi, '-')}`;
+    await page.goto(`/table/${tableId}`);
+
+    // The fixture has cleared `objects` and waited for store ready. Now seed
+    // the bogus pluginId into metadata, then reload to trigger the load path.
+    await page.evaluate((pluginId) => {
+      const store = (globalThis as unknown as TestGlobalThis).__TEST_STORE__;
+      if (!store) {
+        throw new Error('__TEST_STORE__ not exposed');
+      }
+      store.metadata.set('pluginId', pluginId);
+    }, MISSING_PLUGIN_ID);
+
+    // Reload — this re-runs the load effect with the bogus pluginId now in
+    // metadata. `page.reload()` does NOT go through the wrapped goto, so the
+    // fixture's auto-clear does not fire here (and metadata would survive it
+    // anyway).
+    await page.reload();
+
+    // Wait for the new store to be exposed and hydrated.
+    await page.waitForFunction(() =>
+      Boolean((globalThis as unknown as TestGlobalThis).__TEST_STORE__),
+    );
+    await page.evaluate(async () => {
+      const store = (globalThis as unknown as TestGlobalThis).__TEST_STORE__;
+      await store?.waitForReady();
+    });
+
+    // Sanity: metadata persisted across the reload.
+    const persistedPluginId = await page.evaluate(() => {
+      const store = (globalThis as unknown as TestGlobalThis).__TEST_STORE__;
+      return store?.metadata.get('pluginId');
+    });
+    expect(persistedPluginId).toBe(MISSING_PLUGIN_ID);
+
+    // The explicit plugin-not-found error UI should render (not the generic
+    // catch-all variant).
+    const errorContainer = page.getByTestId('table-error-plugin-not-found');
+    await expect(errorContainer).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('table-error-generic')).toHaveCount(0);
+
+    // The missing pluginId is named in the message.
+    const pluginIdElement = page.getByTestId('table-error-plugin-id');
+    await expect(pluginIdElement).toBeVisible();
+    await expect(pluginIdElement).toContainText(MISSING_PLUGIN_ID);
+
+    // Both action buttons render and are interactive.
+    const backButton = page.getByTestId('table-error-back-to-games');
+    const dismissButton = page.getByTestId('table-error-dismiss');
+    await expect(backButton).toBeVisible();
+    await expect(backButton).toBeEnabled();
+    await expect(dismissButton).toBeVisible();
+    await expect(dismissButton).toBeEnabled();
+
+    // Clicking "Back to Games" navigates to the home route.
+    await backButton.click();
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('clicking Reset Table dismisses the error overlay', async ({
+    page,
+  }, testInfo) => {
+    const tableId = `stale-${testInfo.testId.replace(/[^a-z0-9]/gi, '-')}`;
+    await page.goto(`/table/${tableId}`);
+
+    await page.evaluate((pluginId) => {
+      const store = (globalThis as unknown as TestGlobalThis).__TEST_STORE__;
+      if (!store) {
+        throw new Error('__TEST_STORE__ not exposed');
+      }
+      store.metadata.set('pluginId', pluginId);
+    }, MISSING_PLUGIN_ID);
+
+    await page.reload();
+
+    await page.waitForFunction(() =>
+      Boolean((globalThis as unknown as TestGlobalThis).__TEST_STORE__),
+    );
+    await page.evaluate(async () => {
+      const store = (globalThis as unknown as TestGlobalThis).__TEST_STORE__;
+      await store?.waitForReady();
+    });
+
+    const errorContainer = page.getByTestId('table-error-plugin-not-found');
+    await expect(errorContainer).toBeVisible({ timeout: 5000 });
+
+    // Click the secondary "Reset Table" action — it dismisses the overlay
+    // by clearing `packsError` in the React state. (resetTable preserves
+    // pluginId by design, so on a reload the error would re-appear.)
+    await page.getByTestId('table-error-dismiss').click();
+
+    // The error overlay should be gone.
+    await expect(errorContainer).toHaveCount(0);
+  });
+});

--- a/app/src/content/index.ts
+++ b/app/src/content/index.ts
@@ -35,6 +35,7 @@ import {
   getPluginScenarioUrl,
   loadLocalPluginDirectory,
   getLocalPluginFile,
+  PluginNotFoundError,
   type LoadedPlugin,
   type LocalPlugin,
   type PluginManifest,
@@ -64,6 +65,7 @@ export {
   loadAllPlugins,
   loadPlugin,
   loadLocalPluginDirectory,
+  PluginNotFoundError,
 };
 
 // ============================================================================

--- a/app/src/content/pluginLoader.test.ts
+++ b/app/src/content/pluginLoader.test.ts
@@ -6,6 +6,7 @@ import {
   loadPlugin,
   loadLocalPluginDirectory,
   getLocalPluginFile,
+  PluginNotFoundError,
   __resetPluginCacheForTests,
   type PluginRegistry,
   type PluginManifest,
@@ -502,6 +503,26 @@ describe('loadPlugin', () => {
     await expect(loadPlugin('nonexistent-plugin')).rejects.toThrow(
       'Plugin not found: nonexistent-plugin',
     );
+  });
+
+  it('throws PluginNotFoundError carrying pluginId and registry IDs', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRegistry),
+    });
+
+    let caught: unknown;
+    try {
+      await loadPlugin('nonexistent-plugin');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(PluginNotFoundError);
+    const typed = caught as PluginNotFoundError;
+    expect(typed.pluginId).toBe('nonexistent-plugin');
+    expect(typed.availablePluginIds).toEqual(['test-plugin', 'another-plugin']);
+    expect(typed.name).toBe('PluginNotFoundError');
   });
 
   it('should throw when registry fetch fails', async () => {

--- a/app/src/content/pluginLoader.ts
+++ b/app/src/content/pluginLoader.ts
@@ -55,6 +55,32 @@ export interface LoadedPlugin {
 }
 
 // ============================================================================
+// Typed Errors
+// ============================================================================
+
+/**
+ * Thrown when a `pluginId` is requested but does not appear in
+ * `pluginsIndex.json`.
+ *
+ * Distinct from generic load failures (network, parse, validation) so callers
+ * can render a specific UI when a saved table references a plugin that has
+ * since been removed from the registry. See ct-f7f.
+ */
+export class PluginNotFoundError extends Error {
+  /** The pluginId that was looked up but missing from the registry. */
+  readonly pluginId: string;
+  /** IDs present in the registry at lookup time, for diagnostics. */
+  readonly availablePluginIds: string[];
+
+  constructor(pluginId: string, availablePluginIds: string[]) {
+    super(`Plugin not found: ${pluginId}`);
+    this.name = 'PluginNotFoundError';
+    this.pluginId = pluginId;
+    this.availablePluginIds = availablePluginIds;
+  }
+}
+
+// ============================================================================
 // Plugin Registry Loading
 // ============================================================================
 
@@ -300,12 +326,13 @@ async function fetchPluginFresh(pluginId: string): Promise<LoadedPlugin> {
   const entry = registry.plugins.find((p) => p.id === pluginId);
 
   if (!entry) {
+    const availablePluginIds = registry.plugins.map((p) => p.id);
     console.error('[PluginLoader] Plugin not found in registry', {
       errorId: PLUGIN_NOT_FOUND,
       pluginId,
-      availablePlugins: registry.plugins.map((p) => p.id),
+      availablePlugins: availablePluginIds,
     });
-    throw new Error(`Plugin not found: ${pluginId}`);
+    throw new PluginNotFoundError(pluginId, availablePluginIds);
   }
 
   const manifest = await loadPluginManifest(entry.baseUrl);

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1790,6 +1790,14 @@ h1 {
   line-height: 1.5;
 }
 
+.table-error-plugin-id {
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
+  font-weight: 600;
+  color: #fca5a5;
+}
+
 .table-error-actions {
   display: flex;
   gap: 0.75rem;

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -34,11 +34,35 @@ import { useHandPanel } from '../hooks/useHandPanel';
 import { moveAllCardsToHand } from '../store/YjsHandActions';
 import {
   loadPluginAssets,
+  PluginNotFoundError,
   type GameAssets,
   type LoadedScenarioMetadata,
 } from '../content';
 import { CONTENT_RELOAD_INVALID_METADATA } from '../constants/errorIds';
 import { ObjectKind } from '@cardtable2/shared';
+
+/**
+ * Discriminated error state for the table-load path.
+ *
+ * The 'plugin-not-found' variant drives the explicit "this table's plugin is
+ * no longer available" UI (ct-f7f); 'generic' is the catch-all for network /
+ * parse / validation failures we can't usefully disambiguate.
+ */
+type PacksError =
+  | { kind: 'plugin-not-found'; pluginId: string; message: string }
+  | { kind: 'generic'; message: string };
+
+function toPacksError(err: unknown, fallbackMessage: string): PacksError {
+  if (err instanceof PluginNotFoundError) {
+    return {
+      kind: 'plugin-not-found',
+      pluginId: err.pluginId,
+      message: err.message,
+    };
+  }
+  const message = err instanceof Error ? err.message : fallbackMessage;
+  return { kind: 'generic', message };
+}
 
 // Lazy load the Board component
 const Board = lazy(() => import('../components/Board'));
@@ -64,7 +88,7 @@ function Table() {
   const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
   const [gridSnapEnabled, setGridSnapEnabled] = useState(false);
   const [packsLoading, setPacksLoading] = useState(false);
-  const [packsError, setPacksError] = useState<string | null>(null);
+  const [packsError, setPacksError] = useState<PacksError | null>(null);
   const [gameAssets, setGameAssets] = useState<GameAssets | null>(null);
 
   // Hand panel state
@@ -255,10 +279,8 @@ function Table() {
           });
         }
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to load content';
         console.error('[Table] Content loading error:', err);
-        setPacksError(errorMessage);
+        setPacksError(toPacksError(err, 'Failed to load content'));
       } finally {
         setPacksLoading(false);
       }
@@ -439,20 +461,16 @@ function Table() {
           });
         })
         .catch((err: unknown) => {
-          const errorMessage =
-            err instanceof Error
-              ? err.message
-              : 'Failed to load remote scenario';
           const errorObject =
             err instanceof Error ? err : new Error(String(err));
           console.error('[Table] Remote plugin asset loading error:', {
             error: errorObject,
-            errorMessage,
+            errorMessage: errorObject.message,
             pluginId,
             source,
             metadata: loadedScenario,
           });
-          setPacksError(errorMessage);
+          setPacksError(toPacksError(err, 'Failed to load remote scenario'));
         })
         .finally(() => {
           setPacksLoading(false);
@@ -546,12 +564,42 @@ function Table() {
         ) : packsLoading ? (
           <div className="board-fullscreen" />
         ) : packsError ? (
-          <div className="board-fullscreen table-error">
+          <div
+            className="board-fullscreen table-error"
+            data-testid={
+              packsError.kind === 'plugin-not-found'
+                ? 'table-error-plugin-not-found'
+                : 'table-error-generic'
+            }
+          >
             <div className="table-error-content">
-              <div className="table-error-message">{packsError}</div>
+              {packsError.kind === 'plugin-not-found' ? (
+                <div
+                  className="table-error-message"
+                  data-testid="table-error-message"
+                >
+                  This table&apos;s plugin (
+                  <span
+                    className="table-error-plugin-id"
+                    data-testid="table-error-plugin-id"
+                  >
+                    &quot;{packsError.pluginId}&quot;
+                  </span>
+                  ) is no longer available. Choose a different game or load a
+                  local plugin.
+                </div>
+              ) : (
+                <div
+                  className="table-error-message"
+                  data-testid="table-error-message"
+                >
+                  {packsError.message}
+                </div>
+              )}
               <div className="table-error-actions">
                 <button
                   className="table-error-button"
+                  data-testid="table-error-back-to-games"
                   onClick={() => {
                     setPacksError(null);
                     void navigate({ to: '/' });
@@ -561,6 +609,7 @@ function Table() {
                 </button>
                 <button
                   className="table-error-button table-error-button-secondary"
+                  data-testid="table-error-dismiss"
                   onClick={() => {
                     if (store) {
                       resetTable(store);


### PR DESCRIPTION
## Summary

Resolves ct-f7f. When a saved table's `pluginId` no longer exists in `pluginsIndex.json`, the load path now distinguishes that failure from generic load errors and renders an explicit overlay naming the missing plugin.

**Mechanism:**
- `pluginLoader.fetchPluginFresh` throws a typed `PluginNotFoundError` (carrying `pluginId` + `availablePluginIds`) instead of a bare `Error`.
- `routes/table.$id.tsx` replaces the prior `string | null` `packsError` state with a discriminated union (`{ kind: 'plugin-not-found'; pluginId } | { kind: 'generic' }`); `toPacksError` narrows the caught error on `PluginNotFoundError`.
- The error overlay branches on kind: the plugin-not-found case renders the copy from the bead ('This table's plugin ("foo") is no longer available...') with the pluginId in a dedicated span. Both branches share the existing Back-to-Games / Reset Table action row.
- The two existing call-sites that set `packsError` (initial mount load, remote-driven asset load) both go through `toPacksError` so either path yields the same UI.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm --filter "@cardtable2/app" run test` (1040 unit tests pass; new test asserts `PluginNotFoundError` instance + fields)
- [x] `CI=1 pnpm --filter "@cardtable2/app" run test:e2e` (102 E2E tests pass)
- [x] New E2E `e2e/stale-plugin-error.spec.ts` ran 5x in a row with `--repeat-each=5`: 10/10 pass
- [x] `pnpm run build`

E2E covers: seed bogus `pluginId` into Y.Doc metadata, reload `/table/:id`, assert `data-testid="table-error-plugin-not-found"` visible, plugin id text rendered, Back-to-Games button navigates home, Reset Table button dismisses overlay.

Robot generated with [Claude Code](https://claude.com/claude-code)