### PR TITLE
feat(attach): support 8 attachment directions per plugin (ct-2ie)

### DIFF
--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -2708,7 +2708,7 @@ describe('YjsActions - attachCards', () => {
       });
 
       const layout = {
-        direction: 'below' as const,
+        direction: 'bottom' as const,
         revealFraction: 0.25,
         parentOnTop: false,
       };

--- a/app/src/store/attachmentLayout.test.ts
+++ b/app/src/store/attachmentLayout.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_ATTACHMENT_LAYOUT,
+  type AssetPack,
+  type AttachmentDirection,
+  type AttachmentLayout,
+} from '@cardtable2/shared';
 import { computeAttachmentPositions } from './attachmentLayout';
 import { STACK_HEIGHT, STACK_WIDTH } from '../renderer/objects/stack/constants';
 
@@ -7,7 +13,7 @@ describe('computeAttachmentPositions', () => {
 
   it('returns empty array for zero attachments', () => {
     const result = computeAttachmentPositions(parentPos, 0, {
-      direction: 'below',
+      direction: 'bottom',
       revealFraction: 0.25,
     });
     expect(result).toEqual([]);
@@ -15,7 +21,7 @@ describe('computeAttachmentPositions', () => {
 
   it('positions a single attachment below the parent', () => {
     const result = computeAttachmentPositions(parentPos, 1, {
-      direction: 'below',
+      direction: 'bottom',
       revealFraction: 0.25,
     });
 
@@ -27,7 +33,7 @@ describe('computeAttachmentPositions', () => {
 
   it('positions multiple attachments with increasing offsets', () => {
     const result = computeAttachmentPositions(parentPos, 3, {
-      direction: 'below',
+      direction: 'bottom',
       revealFraction: 0.25,
     });
 
@@ -40,7 +46,7 @@ describe('computeAttachmentPositions', () => {
 
   it('fans above the parent', () => {
     const result = computeAttachmentPositions(parentPos, 1, {
-      direction: 'above',
+      direction: 'top',
       revealFraction: 0.25,
     });
 
@@ -70,7 +76,7 @@ describe('computeAttachmentPositions', () => {
 
   it('compresses spacing when exceeding maxBeforeCompress', () => {
     const layoutNormal = {
-      direction: 'below' as const,
+      direction: 'bottom' as const,
       revealFraction: 0.25,
       maxBeforeCompress: 3,
     };
@@ -103,11 +109,11 @@ describe('computeAttachmentPositions', () => {
     const rotatedParent = { x: 100, y: 200, r: 90 }; // 90 degrees
 
     const result = computeAttachmentPositions(rotatedParent, 1, {
-      direction: 'below',
+      direction: 'bottom',
       revealFraction: 0.25,
     });
 
-    // "Below" with 90-degree rotation should fan to the left
+    // "Bottom" with 90-degree rotation should fan to the left
     const step = STACK_HEIGHT * 0.25;
     expect(result[0].x).toBeCloseTo(100 - step, 5);
     expect(result[0].y).toBeCloseTo(200, 5);
@@ -118,12 +124,202 @@ describe('computeAttachmentPositions', () => {
     const rotatedParent = { x: 0, y: 0, r: 45 };
 
     const result = computeAttachmentPositions(rotatedParent, 2, {
-      direction: 'below',
+      direction: 'bottom',
       revealFraction: 0.25,
     });
 
     for (const pos of result) {
       expect(pos.r).toBe(45);
     }
+  });
+
+  // ============================================================================
+  // Corner directions: top-left, top-right, bottom-left, bottom-right
+  // ============================================================================
+  // Each corner uses a symmetric offset on both axes, reusing revealFraction
+  // for both width and height. Signs:
+  //   top-left:     (-W, -H)
+  //   top-right:    (+W, -H)
+  //   bottom-left:  (-W, +H)
+  //   bottom-right: (+W, +H)
+
+  describe('corner directions', () => {
+    type CornerCase = {
+      direction: AttachmentDirection;
+      sx: -1 | 1; // x sign
+      sy: -1 | 1; // y sign
+    };
+
+    const corners: CornerCase[] = [
+      { direction: 'top-left', sx: -1, sy: -1 },
+      { direction: 'top-right', sx: 1, sy: -1 },
+      { direction: 'bottom-left', sx: -1, sy: 1 },
+      { direction: 'bottom-right', sx: 1, sy: 1 },
+    ];
+
+    for (const { direction, sx, sy } of corners) {
+      describe(`direction='${direction}'`, () => {
+        it('positions a single attachment with symmetric (dx, dy)', () => {
+          const result = computeAttachmentPositions(parentPos, 1, {
+            direction,
+            revealFraction: 0.25,
+          });
+
+          expect(result).toHaveLength(1);
+          expect(result[0].x).toBeCloseTo(100 + sx * STACK_WIDTH * 0.25, 5);
+          expect(result[0].y).toBeCloseTo(200 + sy * STACK_HEIGHT * 0.25, 5);
+          expect(result[0].r).toBe(0);
+        });
+
+        it('positions 2 attachments with linearly increasing (dx, dy)', () => {
+          const result = computeAttachmentPositions(parentPos, 2, {
+            direction,
+            revealFraction: 0.25,
+          });
+
+          expect(result).toHaveLength(2);
+          const stepX = sx * STACK_WIDTH * 0.25;
+          const stepY = sy * STACK_HEIGHT * 0.25;
+          expect(result[0].x).toBeCloseTo(100 + stepX, 5);
+          expect(result[0].y).toBeCloseTo(200 + stepY, 5);
+          expect(result[1].x).toBeCloseTo(100 + stepX * 2, 5);
+          expect(result[1].y).toBeCloseTo(200 + stepY * 2, 5);
+        });
+
+        it('positions 3 attachments with linearly increasing (dx, dy)', () => {
+          const result = computeAttachmentPositions(parentPos, 3, {
+            direction,
+            revealFraction: 0.25,
+          });
+
+          expect(result).toHaveLength(3);
+          const stepX = sx * STACK_WIDTH * 0.25;
+          const stepY = sy * STACK_HEIGHT * 0.25;
+          for (let i = 0; i < 3; i++) {
+            expect(result[i].x).toBeCloseTo(100 + stepX * (i + 1), 5);
+            expect(result[i].y).toBeCloseTo(200 + stepY * (i + 1), 5);
+          }
+        });
+
+        it('rotates the offset vector by parent _pos.r (90 degrees)', () => {
+          // 90deg rotation: (x', y') = (-y, x). So a corner offset (sx*W, sy*H)
+          // rotated by 90deg becomes (-sy*H, sx*W).
+          const rotatedParent = { x: 100, y: 200, r: 90 };
+          const result = computeAttachmentPositions(rotatedParent, 1, {
+            direction,
+            revealFraction: 0.25,
+          });
+
+          const expectedDx = -sy * STACK_HEIGHT * 0.25;
+          const expectedDy = sx * STACK_WIDTH * 0.25;
+          expect(result[0].x).toBeCloseTo(100 + expectedDx, 5);
+          expect(result[0].y).toBeCloseTo(200 + expectedDy, 5);
+          expect(result[0].r).toBe(90);
+        });
+
+        it('compression scales both axes proportionally at 5+ attachments', () => {
+          const layout: AttachmentLayout = {
+            direction,
+            revealFraction: 0.25,
+            maxBeforeCompress: 3,
+          };
+
+          // With count=6, maxBeforeCompress=3, revealFraction=0.25:
+          //   effectiveReveal = (0.25 * 3) / 6 = 0.125
+          // The last card (index 5) sits at offset * 6, so:
+          //   xLast = 100 + sx * STACK_WIDTH  * 0.125 * 6 = 100 + sx * STACK_WIDTH  * 0.75
+          //   yLast = 200 + sy * STACK_HEIGHT * 0.125 * 6 = 200 + sy * STACK_HEIGHT * 0.75
+          // Total reach equals 3 cards uncompressed (3 * 0.25 = 0.75). Both axes scale together.
+          const compressed = computeAttachmentPositions(parentPos, 6, layout);
+          expect(compressed).toHaveLength(6);
+
+          const expectedTotalDx = sx * STACK_WIDTH * 0.75;
+          const expectedTotalDy = sy * STACK_HEIGHT * 0.75;
+          expect(compressed[5].x).toBeCloseTo(100 + expectedTotalDx, 5);
+          expect(compressed[5].y).toBeCloseTo(200 + expectedTotalDy, 5);
+
+          // Sanity: ratio of x-step to y-step is preserved (W*reveal : H*reveal),
+          // i.e., compression scales both axes by the same factor.
+          const stepX = compressed[1].x - compressed[0].x;
+          const stepY = compressed[1].y - compressed[0].y;
+          // Sign-corrected ratio should equal STACK_WIDTH / STACK_HEIGHT.
+          expect(Math.abs(stepX) / Math.abs(stepY)).toBeCloseTo(
+            STACK_WIDTH / STACK_HEIGHT,
+            5,
+          );
+          // Per-card step magnitude: 0.125 of dimension.
+          expect(Math.abs(stepX)).toBeCloseTo(STACK_WIDTH * 0.125, 5);
+          expect(Math.abs(stepY)).toBeCloseTo(STACK_HEIGHT * 0.125, 5);
+        });
+      });
+    }
+  });
+});
+
+// ============================================================================
+// Plugin config-flow: resolving attachmentLayout from the active GameAssets
+// ============================================================================
+// Mirrors BoardMessageBus.ts (~lines 135-138 / 231-234), which reads:
+//
+//   const gameAssets = ctx.store.getGameAssets();
+//   const layout = gameAssets?.packs.find((p) => p.attachmentLayout)
+//                  ?.attachmentLayout;
+//
+// We assert the lookup returns the configured direction when set, and falls
+// through to DEFAULT_ATTACHMENT_LAYOUT when no pack defines one. This is the
+// plugin-config-flow check we agreed to in lieu of E2E.
+
+describe('attachmentLayout: plugin config flow', () => {
+  function resolveAttachmentLayout(
+    packs: Pick<AssetPack, 'attachmentLayout'>[],
+  ): AttachmentLayout {
+    return (
+      packs.find((p) => p.attachmentLayout)?.attachmentLayout ??
+      DEFAULT_ATTACHMENT_LAYOUT
+    );
+  }
+
+  it('returns the pack-configured direction when a pack defines attachmentLayout', () => {
+    const layout: AttachmentLayout = {
+      direction: 'top-right',
+      revealFraction: 0.3,
+      maxBeforeCompress: 4,
+      parentOnTop: false,
+    };
+    const packs = [{ attachmentLayout: layout }];
+
+    const resolved = resolveAttachmentLayout(packs);
+    expect(resolved).toBe(layout);
+    expect(resolved.direction).toBe('top-right');
+  });
+
+  it('returns DEFAULT_ATTACHMENT_LAYOUT when no pack defines attachmentLayout', () => {
+    const packs: Pick<AssetPack, 'attachmentLayout'>[] = [
+      {},
+      { attachmentLayout: undefined },
+    ];
+
+    const resolved = resolveAttachmentLayout(packs);
+    expect(resolved).toBe(DEFAULT_ATTACHMENT_LAYOUT);
+    expect(resolved.direction).toBe('bottom'); // Default direction post-rename
+  });
+
+  it('returns the first pack with attachmentLayout (matches BoardMessageBus.find())', () => {
+    const first: AttachmentLayout = {
+      direction: 'left',
+      revealFraction: 0.2,
+    };
+    const second: AttachmentLayout = {
+      direction: 'right',
+      revealFraction: 0.4,
+    };
+    const packs = [
+      {}, // no layout
+      { attachmentLayout: first },
+      { attachmentLayout: second },
+    ];
+
+    const resolved = resolveAttachmentLayout(packs);
+    expect(resolved).toBe(first);
   });
 });

--- a/app/src/store/attachmentLayout.ts
+++ b/app/src/store/attachmentLayout.ts
@@ -32,21 +32,40 @@ export function computeAttachmentPositions(
     effectiveReveal = (revealFraction * maxBeforeCompress) / attachmentCount;
   }
 
-  // Determine offset per card based on direction
+  // Determine offset per card based on direction.
+  // Corner directions use a symmetric offset reusing effectiveReveal on both axes.
+  const dx = STACK_WIDTH * effectiveReveal;
+  const dy = STACK_HEIGHT * effectiveReveal;
   let baseDx = 0;
   let baseDy = 0;
   switch (direction) {
-    case 'below':
-      baseDy = STACK_HEIGHT * effectiveReveal;
+    case 'top':
+      baseDy = -dy;
       break;
-    case 'above':
-      baseDy = -STACK_HEIGHT * effectiveReveal;
+    case 'bottom':
+      baseDy = dy;
       break;
     case 'left':
-      baseDx = -STACK_WIDTH * effectiveReveal;
+      baseDx = -dx;
       break;
     case 'right':
-      baseDx = STACK_WIDTH * effectiveReveal;
+      baseDx = dx;
+      break;
+    case 'top-left':
+      baseDx = -dx;
+      baseDy = -dy;
+      break;
+    case 'top-right':
+      baseDx = dx;
+      baseDy = -dy;
+      break;
+    case 'bottom-left':
+      baseDx = -dx;
+      baseDy = dy;
+      break;
+    case 'bottom-right':
+      baseDx = dx;
+      baseDy = dy;
       break;
   }
 

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -111,17 +111,32 @@ export interface IconTypeDef {
 // Card-on-Card Attachment Layout Configuration
 // ============================================================================
 
-export type AttachmentDirection = 'below' | 'above' | 'left' | 'right';
+/**
+ * Direction in which attached cards fan out from a parent card.
+ *
+ * Eight supported values: 4 sides (top, bottom, left, right) and 4 corners
+ * (top-left, top-right, bottom-left, bottom-right). Corner directions use a
+ * symmetric offset on both axes derived from `revealFraction`.
+ */
+export type AttachmentDirection =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right';
 
 export interface AttachmentLayout {
-  direction: AttachmentDirection; // Fan direction for attached cards
-  revealFraction: number; // 0-1, portion of attached card visible (default: 0.25)
+  direction: AttachmentDirection; // Fan direction for attached cards (4 sides + 4 corners)
+  revealFraction: number; // 0-1, portion of attached card visible per axis (default: 0.25). Corners use this for both axes.
   maxBeforeCompress?: number; // Compress spacing beyond this count (default: 5)
   parentOnTop?: boolean; // Whether parent renders above children (default: true)
 }
 
 export const DEFAULT_ATTACHMENT_LAYOUT: AttachmentLayout = {
-  direction: 'below',
+  direction: 'bottom',
   revealFraction: 0.25,
   maxBeforeCompress: 5,
   parentOnTop: true,


### PR DESCRIPTION
## Summary
- Extends per-plugin `attachmentLayout.direction` from 4 sides to **8 values** (4 sides + 4 corners): `top`, `bottom`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`. Corner offsets are symmetric, reusing `revealFraction` for both axes.
- **Breaking change to AssetPack shape:** renames `'above'`/`'below'` to `'top'`/`'bottom'`. Default direction is now `'bottom'`.
- In-repo testgame plugin needs no manifest change (doesn't set `attachmentLayout`, so the new default applies). **Marvel Champions plugin in the separate `card-data` repo will need a one-line update post-merge if it sets `'above'` or `'below'` — tracked in ct-a8d.**

Closes ct-pvs, ct-1sq, ct-tht, ct-2x4, ct-2ie. Filed and resolved ct-ae4 (test-cascade pattern memory). ct-a8d (MC plugin migration) deferred.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 1063/1063 pass (32 in `attachmentLayout.test.ts`, covering 4 corners x {1,2,3 attachments} x rotation + 6-card compression + plugin-config-flow lookup)
- [x] `pnpm run lint` passes
- [ ] Manual: load testgame in dev, confirm no console errors and attachments render at the default `'bottom'` position
- [ ] Post-merge: update Marvel Champions plugin manifest in `card-data` repo (ct-a8d)