### PR TITLE
feat(dev): attachment direction override + E2E (ct-t1c)

### DIFF
--- a/app/e2e/attachment-layout.spec.ts
+++ b/app/e2e/attachment-layout.spec.ts
@@ -14,7 +14,7 @@
  * 1.  Navigate to a fresh `/dev/table/:id` and seed two single-card
  *     stacks via `__TEST_STORE__.setObject` (deterministic IDs and
  *     positions, no plugin needed).
- * 2.  Set the override to `'top-right'` via `__ctTest.setAttachmentDirection`.
+ * 2.  Set the override to `'top-right'` via `__ctDevTools.setAttachmentDirection`.
  * 3.  Drive a real Alt-drag from the would-be-child stack onto the
  *     would-be-parent stack.  Alt held forces the renderer's pointer
  *     handler to emit `attach-cards` (not `stack-objects`) — see
@@ -61,7 +61,7 @@ interface PageTestStore {
   getAllObjects: () => Map<string, { _kind: string; _pos: Pos }>;
 }
 
-interface PageCtTest {
+interface PageCtDevTools {
   setAttachmentDirection: (dir: AttachmentDirection | null) => void;
 }
 
@@ -72,7 +72,7 @@ interface PageTestBoard {
 
 interface PageGlobals {
   __TEST_STORE__?: PageTestStore;
-  __ctTest?: PageCtTest;
+  __ctDevTools?: PageCtDevTools;
   __TEST_BOARD__?: PageTestBoard;
 }
 
@@ -167,7 +167,7 @@ test.describe('Attachment direction override (ct-t1c)', () => {
     });
     await page.waitForFunction(() => {
       const globals = globalThis as unknown as PageGlobals;
-      return Boolean(globals.__ctTest);
+      return Boolean(globals.__ctDevTools);
     });
 
     // Make sure no override leaked from a prior run on the same dev
@@ -175,7 +175,7 @@ test.describe('Attachment direction override (ct-t1c)', () => {
     // of `__TEST_STORE__`, so the auto-clear fixture does not touch it.
     await page.evaluate(() => {
       const globals = globalThis as unknown as PageGlobals;
-      globals.__ctTest?.setAttachmentDirection(null);
+      globals.__ctDevTools?.setAttachmentDirection(null);
     });
   });
 
@@ -184,7 +184,7 @@ test.describe('Attachment direction override (ct-t1c)', () => {
     // the next test.
     await page.evaluate(() => {
       const globals = globalThis as unknown as PageGlobals;
-      globals.__ctTest?.setAttachmentDirection(null);
+      globals.__ctDevTools?.setAttachmentDirection(null);
     });
   });
 
@@ -204,7 +204,7 @@ test.describe('Attachment direction override (ct-t1c)', () => {
     // BoardMessageBus reads it inside the `attach-cards` handler.
     await page.evaluate(() => {
       const globals = globalThis as unknown as PageGlobals;
-      globals.__ctTest?.setAttachmentDirection('top-right');
+      globals.__ctDevTools?.setAttachmentDirection('top-right');
     });
 
     // Click the child stack to select it (matches the pattern used by
@@ -287,8 +287,8 @@ test.describe('Attachment direction override (ct-t1c)', () => {
     // direction (which is `'bottom'` per `DEFAULT_ATTACHMENT_LAYOUT`).
     await page.evaluate(() => {
       const globals = globalThis as unknown as PageGlobals;
-      globals.__ctTest?.setAttachmentDirection('top-right');
-      globals.__ctTest?.setAttachmentDirection(null);
+      globals.__ctDevTools?.setAttachmentDirection('top-right');
+      globals.__ctDevTools?.setAttachmentDirection(null);
     });
 
     await page.mouse.click(seeded.childViewport.x, seeded.childViewport.y);

--- a/app/e2e/attachment-layout.spec.ts
+++ b/app/e2e/attachment-layout.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * E2E for the dev-only attachment direction override (ct-t1c).
+ *
+ * Locks in the full pipeline
+ *   plugin manifest -> BoardMessageBus -> attachCards ->
+ *   computeAttachmentPositions -> _pos
+ * for a non-default direction (`'top-right'`).  Epic ct-2ie shipped
+ * 8-direction support with thorough unit tests of the math, but no
+ * shipped plugin currently sets a non-default `attachmentLayout.direction`,
+ * so without this spec the runtime wiring goes uncovered.
+ *
+ * Test strategy
+ * -------------
+ * 1.  Navigate to a fresh `/dev/table/:id` and seed two single-card
+ *     stacks via `__TEST_STORE__.setObject` (deterministic IDs and
+ *     positions, no plugin needed).
+ * 2.  Set the override to `'top-right'` via `__ctTest.setAttachmentDirection`.
+ * 3.  Drive a real Alt-drag from the would-be-child stack onto the
+ *     would-be-parent stack.  Alt held forces the renderer's pointer
+ *     handler to emit `attach-cards` (not `stack-objects`) — see
+ *     `app/src/renderer/handlers/pointer.ts` (~line 1305 and ~1124).
+ * 4.  After the renderer settles, read the child's `_pos` and assert
+ *     it sits to the upper-right of the parent (`dx > 0 && dy < 0`),
+ *     proving the override was actually applied to the math.
+ * 5.  Clear the override and repeat — assert the default `'bottom'`
+ *     direction is restored (`dy > 0`).
+ */
+
+import { test, expect } from './_fixtures';
+import type { AttachmentDirection } from '@cardtable2/shared';
+
+// Local types for use inside `page.evaluate` callbacks.  Mirrors the
+// store/window surface but kept narrow to this spec so the page-side
+// type assertions stay loose.
+interface Pos {
+  x: number;
+  y: number;
+  r: number;
+}
+
+interface SeededStack {
+  id: string;
+  pos: Pos;
+}
+
+interface SeededPair {
+  parent: SeededStack;
+  child: SeededStack;
+}
+
+// Window types used inside page.evaluate.  The real types live in
+// `app/src/vite-env.d.ts`; redeclaring the slice we use keeps the
+// page-side code self-contained.
+interface YMapLike {
+  get: (key: string) => unknown;
+}
+
+interface PageTestStore {
+  setObject: (id: string, obj: Record<string, unknown>) => void;
+  getObjectYMap: (id: string) => YMapLike | undefined;
+  getAllObjects: () => Map<string, { _kind: string; _pos: Pos }>;
+}
+
+interface PageCtTest {
+  setAttachmentDirection: (dir: AttachmentDirection | null) => void;
+}
+
+interface PageTestBoard {
+  waitForRenderer: () => Promise<void>;
+  waitForSelectionSettled: () => Promise<void>;
+}
+
+interface PageGlobals {
+  __TEST_STORE__?: PageTestStore;
+  __ctTest?: PageCtTest;
+  __TEST_BOARD__?: PageTestBoard;
+}
+
+/**
+ * Seed a parent stack on the left and a child-candidate stack on the
+ * right.  Uses fixed IDs so we don't have to enumerate the store after
+ * seeding.  Returns viewport coords for both stacks so callers can
+ * drive a real `page.mouse` drag.
+ */
+async function seedTwoStacks(
+  page: Parameters<Parameters<typeof test>[1]>[0]['page'],
+): Promise<SeededPair & { parentViewport: Pos; childViewport: Pos }> {
+  return await page.evaluate(() => {
+    const globals = globalThis as unknown as PageGlobals;
+    const store = globals.__TEST_STORE__;
+    if (!store) {
+      throw new Error('__TEST_STORE__ not exposed — must run on /dev/table');
+    }
+
+    const parentPos = { x: -100, y: 0, r: 0 };
+    const childPos = { x: 100, y: 0, r: 0 };
+    const parentId = 'e2e-attach-parent';
+    const childId = 'e2e-attach-child';
+
+    // Minimal stack shapes.  `_kind: 'stack'` matches `ObjectKind.Stack`
+    // (the enum value is the string `'stack'`); other fields mirror the
+    // defaults `createObject` would produce for a single-card stack.
+    store.setObject(parentId, {
+      _kind: 'stack',
+      _containerId: null,
+      _pos: parentPos,
+      _sortKey: '0001',
+      _locked: false,
+      _selectedBy: null,
+      _meta: {},
+      _cards: ['e2e-parent-card'],
+      _faceUp: true,
+    });
+    store.setObject(childId, {
+      _kind: 'stack',
+      _containerId: null,
+      _pos: childPos,
+      _sortKey: '0002',
+      _locked: false,
+      _selectedBy: null,
+      _meta: {},
+      _cards: ['e2e-child-card'],
+      _faceUp: true,
+    });
+
+    const canvas = document.querySelector('canvas');
+    if (!canvas) throw new Error('No canvas element');
+    const rect = canvas.getBoundingClientRect();
+    const cx = canvas.clientWidth / 2;
+    const cy = canvas.clientHeight / 2;
+
+    return {
+      parent: { id: parentId, pos: parentPos },
+      child: { id: childId, pos: childPos },
+      parentViewport: {
+        x: rect.left + cx + parentPos.x,
+        y: rect.top + cy + parentPos.y,
+        r: 0,
+      },
+      childViewport: {
+        x: rect.left + cx + childPos.x,
+        y: rect.top + cy + childPos.y,
+        r: 0,
+      },
+    };
+  });
+}
+
+test.describe('Attachment direction override (ct-t1c)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const tableId = `attach-${testInfo.testId.replace(/[^a-z0-9]/gi, '-')}`;
+    await page.goto(`/dev/table/${tableId}`);
+
+    await expect(page.locator('text=Store: ✓ Ready')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId('worker-status')).toContainText(
+      'Initialized',
+      { timeout: 5000 },
+    );
+    await expect(page.getByTestId('board-canvas')).toBeVisible({
+      timeout: 5000,
+    });
+    await page.waitForFunction(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      return Boolean(globals.__TEST_BOARD__);
+    });
+    await page.waitForFunction(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      return Boolean(globals.__ctTest);
+    });
+
+    // Make sure no override leaked from a prior run on the same dev
+    // server.  The override is module-level state in the page, not part
+    // of `__TEST_STORE__`, so the auto-clear fixture does not touch it.
+    await page.evaluate(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      globals.__ctTest?.setAttachmentDirection(null);
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Always release the override so a flaky teardown doesn't leak into
+    // the next test.
+    await page.evaluate(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      globals.__ctTest?.setAttachmentDirection(null);
+    });
+  });
+
+  test('top-right override places child to the upper-right of parent', async ({
+    page,
+  }) => {
+    const seeded = await seedTwoStacks(page);
+
+    // Wait for renderer to receive the seeded objects so the drag can
+    // hit them.
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForRenderer();
+    });
+
+    // Apply the dev override BEFORE the attach fires.  The
+    // BoardMessageBus reads it inside the `attach-cards` handler.
+    await page.evaluate(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      globals.__ctTest?.setAttachmentDirection('top-right');
+    });
+
+    // Click the child stack to select it (matches the pattern used by
+    // `stack-operations.spec.ts`).
+    await page.mouse.click(seeded.childViewport.x, seeded.childViewport.y);
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForSelectionSettled();
+    });
+
+    // Alt-drag the child onto the parent.  Alt forces the renderer's
+    // pointer handler to emit `attach-cards` (not `stack-objects`) —
+    // see `app/src/renderer/handlers/pointer.ts:1305`.
+    await page.keyboard.down('Alt');
+    await page.mouse.move(seeded.childViewport.x, seeded.childViewport.y);
+    await page.mouse.down();
+    await page.mouse.move(seeded.parentViewport.x, seeded.parentViewport.y, {
+      steps: 10,
+    });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    // Let the renderer process the attach-cards round-trip.
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForRenderer();
+    });
+
+    // Read both positions back from the store.  After attach the child
+    // is repositioned by `computeAttachmentPositions(parentPos, 1,
+    // {direction: 'top-right', revealFraction: 0.25})` — for a single
+    // attachment that's `(parent.x + STACK_WIDTH*0.25, parent.y -
+    // STACK_HEIGHT*0.25)`.  We assert the *signs* of the deltas rather
+    // than exact magnitudes so the test isn't coupled to STACK_WIDTH /
+    // STACK_HEIGHT or the default revealFraction.
+    const positions = await page.evaluate(
+      ({ parentId, childId }: { parentId: string; childId: string }) => {
+        const globals = globalThis as unknown as PageGlobals;
+        const store = globals.__TEST_STORE__;
+        if (!store) throw new Error('__TEST_STORE__ went away');
+        const parent = store.getObjectYMap(parentId);
+        const child = store.getObjectYMap(childId);
+        return {
+          parentPos: parent?.get('_pos') as Pos | undefined,
+          childPos: child?.get('_pos') as Pos | undefined,
+          childAttachedTo: child?.get('_attachedToId') as string | undefined,
+          parentAttachments: parent?.get('_attachedCardIds') as
+            | string[]
+            | undefined,
+        };
+      },
+      { parentId: seeded.parent.id, childId: seeded.child.id },
+    );
+
+    // Sanity: the attach happened at all.
+    expect(positions.childAttachedTo).toBe(seeded.parent.id);
+    expect(positions.parentAttachments).toEqual([seeded.child.id]);
+
+    // The substantive override-applied assertion:
+    // top-right => child shifted +x, -y relative to parent.
+    expect(positions.parentPos).toBeTruthy();
+    expect(positions.childPos).toBeTruthy();
+    if (!positions.parentPos || !positions.childPos) return;
+    expect(positions.childPos.x).toBeGreaterThan(positions.parentPos.x);
+    expect(positions.childPos.y).toBeLessThan(positions.parentPos.y);
+  });
+
+  test('cleared override falls back to default bottom direction', async ({
+    page,
+  }) => {
+    const seeded = await seedTwoStacks(page);
+
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForRenderer();
+    });
+
+    // Set then immediately clear the override.  The BoardMessageBus
+    // should ignore it once cleared and fall back to the default
+    // direction (which is `'bottom'` per `DEFAULT_ATTACHMENT_LAYOUT`).
+    await page.evaluate(() => {
+      const globals = globalThis as unknown as PageGlobals;
+      globals.__ctTest?.setAttachmentDirection('top-right');
+      globals.__ctTest?.setAttachmentDirection(null);
+    });
+
+    await page.mouse.click(seeded.childViewport.x, seeded.childViewport.y);
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForSelectionSettled();
+    });
+
+    await page.keyboard.down('Alt');
+    await page.mouse.move(seeded.childViewport.x, seeded.childViewport.y);
+    await page.mouse.down();
+    await page.mouse.move(seeded.parentViewport.x, seeded.parentViewport.y, {
+      steps: 10,
+    });
+    await page.mouse.up();
+    await page.keyboard.up('Alt');
+
+    await page.evaluate(async () => {
+      const globals = globalThis as unknown as PageGlobals;
+      await globals.__TEST_BOARD__?.waitForRenderer();
+    });
+
+    const positions = await page.evaluate(
+      ({ parentId, childId }: { parentId: string; childId: string }) => {
+        const globals = globalThis as unknown as PageGlobals;
+        const store = globals.__TEST_STORE__;
+        if (!store) throw new Error('__TEST_STORE__ went away');
+        const parent = store.getObjectYMap(parentId);
+        const child = store.getObjectYMap(childId);
+        return {
+          parentPos: parent?.get('_pos') as Pos | undefined,
+          childPos: child?.get('_pos') as Pos | undefined,
+          childAttachedTo: child?.get('_attachedToId') as string | undefined,
+        };
+      },
+      { parentId: seeded.parent.id, childId: seeded.child.id },
+    );
+
+    expect(positions.childAttachedTo).toBe(seeded.parent.id);
+    expect(positions.parentPos).toBeTruthy();
+    expect(positions.childPos).toBeTruthy();
+    if (!positions.parentPos || !positions.childPos) return;
+    // Default direction is 'bottom' => child shifted +y (downward) and
+    // x roughly unchanged.  Assert the y-axis sign change so this test
+    // would catch a regression where the override leaks across calls.
+    expect(positions.childPos.y).toBeGreaterThan(positions.parentPos.y);
+  });
+});

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -14,6 +14,7 @@ import {
   areAllSelectedStacksExhausted,
   areAllSelectedStacksReady,
 } from '../store/YjsSelectors';
+import { resolveEffectiveAttachmentLayout } from '../store/attachmentLayout';
 import {
   loadPluginAssets,
   loadScenarioFromPlugin,
@@ -212,7 +213,11 @@ export function registerDefaultActions(): void {
     },
     execute: (ctx) => {
       const cardId = ctx.selection.ids[0];
-      const success = detachCard(ctx.store, cardId);
+      const success = detachCard(
+        ctx.store,
+        cardId,
+        resolveEffectiveAttachmentLayout(ctx.store),
+      );
       if (success) {
         console.log(`Detached card ${cardId}`);
       }

--- a/app/src/components/Board/BoardMessageBus.ts
+++ b/app/src/components/Board/BoardMessageBus.ts
@@ -1,6 +1,10 @@
 import { MessageHandlerRegistry } from '../../messaging/MessageHandlerRegistry';
-import type { RendererToMainMessage, TableObject } from '@cardtable2/shared';
-import { isValidPosition } from '@cardtable2/shared';
+import type {
+  AttachmentLayout,
+  RendererToMainMessage,
+  TableObject,
+} from '@cardtable2/shared';
+import { DEFAULT_ATTACHMENT_LAYOUT, isValidPosition } from '@cardtable2/shared';
 import type { IRendererAdapter } from '../../renderer/IRendererAdapter';
 import type { YjsStore } from '../../store/YjsStore';
 import { toTableObject } from '../../store/YjsStore';
@@ -16,6 +20,7 @@ import {
 } from '../../store/YjsActions';
 import { getSelectedObjectIds } from '../../store/YjsSelectors';
 import { dbg } from '../../dev/dbg';
+import { getAttachmentDirectionOverride } from '../../dev/attachmentOverride';
 
 export interface BoardHandlerContext {
   // Core dependencies
@@ -232,7 +237,29 @@ export class BoardMessageBus {
         const layout = gameAssets?.packs.find(
           (p) => p.attachmentLayout,
         )?.attachmentLayout;
-        const attached = attachCards(ctx.store, msg.ids, msg.targetId, layout);
+
+        // Dev/E2E-only direction override (ct-t1c).  Lets a test or MCP
+        // session force a non-default direction without authoring a
+        // throwaway plugin, so we have regression coverage for the full
+        // attach pipeline at directions like `'top-right'`.  In
+        // production the override is always `null` (the setter sits
+        // behind `__ctTest`, which is dev/E2E-build only) so this branch
+        // is dead and behavior is identical to today.
+        const overrideDir = getAttachmentDirectionOverride();
+        const effectiveLayout: AttachmentLayout | undefined =
+          overrideDir !== null
+            ? {
+                ...(layout ?? DEFAULT_ATTACHMENT_LAYOUT),
+                direction: overrideDir,
+              }
+            : layout;
+
+        const attached = attachCards(
+          ctx.store,
+          msg.ids,
+          msg.targetId,
+          effectiveLayout,
+        );
         if (attached.length === 0) {
           ctx.addMessage(
             'No cards were attached. Target may have been modified.',

--- a/app/src/components/Board/BoardMessageBus.ts
+++ b/app/src/components/Board/BoardMessageBus.ts
@@ -259,7 +259,11 @@ export class BoardMessageBus {
     this.registry.register('detach-card', (msg, ctx) => {
       console.log(`[BoardMessageBus] Detaching card ${msg.cardId}`);
       try {
-        const success = detachCard(ctx.store, msg.cardId);
+        const success = detachCard(
+          ctx.store,
+          msg.cardId,
+          resolveEffectiveAttachmentLayout(ctx.store),
+        );
         if (success) {
           console.log(
             `[BoardMessageBus] Successfully detached card ${msg.cardId}`,

--- a/app/src/components/Board/BoardMessageBus.ts
+++ b/app/src/components/Board/BoardMessageBus.ts
@@ -1,10 +1,6 @@
 import { MessageHandlerRegistry } from '../../messaging/MessageHandlerRegistry';
-import type {
-  AttachmentLayout,
-  RendererToMainMessage,
-  TableObject,
-} from '@cardtable2/shared';
-import { DEFAULT_ATTACHMENT_LAYOUT, isValidPosition } from '@cardtable2/shared';
+import type { RendererToMainMessage, TableObject } from '@cardtable2/shared';
+import { isValidPosition } from '@cardtable2/shared';
 import type { IRendererAdapter } from '../../renderer/IRendererAdapter';
 import type { YjsStore } from '../../store/YjsStore';
 import { toTableObject } from '../../store/YjsStore';
@@ -19,8 +15,8 @@ import {
   detachCard,
 } from '../../store/YjsActions';
 import { getSelectedObjectIds } from '../../store/YjsSelectors';
+import { resolveEffectiveAttachmentLayout } from '../../store/attachmentLayout';
 import { dbg } from '../../dev/dbg';
-import { getAttachmentDirectionOverride } from '../../dev/attachmentOverride';
 
 export interface BoardHandlerContext {
   // Core dependencies
@@ -137,11 +133,11 @@ export class BoardMessageBus {
     // Object state
     this.registry.register('objects-moved', (msg, ctx) => {
       console.log(`[BoardMessageBus] ${msg.updates.length} object(s) moved`);
-      const gameAssets = ctx.store.getGameAssets();
-      const layout = gameAssets?.packs.find(
-        (p) => p.attachmentLayout,
-      )?.attachmentLayout;
-      moveObjects(ctx.store, msg.updates, layout);
+      moveObjects(
+        ctx.store,
+        msg.updates,
+        resolveEffectiveAttachmentLayout(ctx.store),
+      );
     });
 
     this.registry.register('stack-objects', (msg, ctx) => {
@@ -232,33 +228,11 @@ export class BoardMessageBus {
         `[BoardMessageBus] Attaching ${msg.ids.length} card(s) to ${msg.targetId}`,
       );
       try {
-        // Use game-defined attachment layout if available
-        const gameAssets = ctx.store.getGameAssets();
-        const layout = gameAssets?.packs.find(
-          (p) => p.attachmentLayout,
-        )?.attachmentLayout;
-
-        // Dev/E2E-only direction override (ct-t1c).  Lets a test or MCP
-        // session force a non-default direction without authoring a
-        // throwaway plugin, so we have regression coverage for the full
-        // attach pipeline at directions like `'top-right'`.  In
-        // production the override is always `null` (the setter sits
-        // behind `__ctTest`, which is dev/E2E-build only) so this branch
-        // is dead and behavior is identical to today.
-        const overrideDir = getAttachmentDirectionOverride();
-        const effectiveLayout: AttachmentLayout | undefined =
-          overrideDir !== null
-            ? {
-                ...(layout ?? DEFAULT_ATTACHMENT_LAYOUT),
-                direction: overrideDir,
-              }
-            : layout;
-
         const attached = attachCards(
           ctx.store,
           msg.ids,
           msg.targetId,
-          effectiveLayout,
+          resolveEffectiveAttachmentLayout(ctx.store),
         );
         if (attached.length === 0) {
           ctx.addMessage(

--- a/app/src/dev/attachmentOverride.test.ts
+++ b/app/src/dev/attachmentOverride.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the dev/test-only attachment direction override module.
+ *
+ * The module is essentially a typed singleton; these tests just lock in
+ * the set/get/clear contract so a future refactor (e.g. moving the value
+ * into a context or store) doesn't silently break the read site in
+ * `BoardMessageBus.attach-cards`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getAttachmentDirectionOverride,
+  setAttachmentDirectionOverride,
+  __resetAttachmentOverrideForTests,
+} from './attachmentOverride';
+
+describe('attachmentOverride', () => {
+  beforeEach(() => {
+    __resetAttachmentOverrideForTests();
+  });
+
+  it('returns null by default (no override set)', () => {
+    expect(getAttachmentDirectionOverride()).toBeNull();
+  });
+
+  it('round-trips a single direction (set, get)', () => {
+    setAttachmentDirectionOverride('top-right');
+    expect(getAttachmentDirectionOverride()).toBe('top-right');
+  });
+
+  it('overwrites the previous value when set again', () => {
+    setAttachmentDirectionOverride('top-right');
+    setAttachmentDirectionOverride('bottom-left');
+    expect(getAttachmentDirectionOverride()).toBe('bottom-left');
+  });
+
+  it('clears the override when set to null', () => {
+    setAttachmentDirectionOverride('top-right');
+    setAttachmentDirectionOverride(null);
+    expect(getAttachmentDirectionOverride()).toBeNull();
+  });
+
+  it('__resetAttachmentOverrideForTests clears any prior value', () => {
+    setAttachmentDirectionOverride('right');
+    __resetAttachmentOverrideForTests();
+    expect(getAttachmentDirectionOverride()).toBeNull();
+  });
+
+  it('accepts each of the eight supported directions', () => {
+    const directions = [
+      'top',
+      'bottom',
+      'left',
+      'right',
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+    ] as const;
+
+    for (const dir of directions) {
+      setAttachmentDirectionOverride(dir);
+      expect(getAttachmentDirectionOverride()).toBe(dir);
+    }
+  });
+});

--- a/app/src/dev/attachmentOverride.ts
+++ b/app/src/dev/attachmentOverride.ts
@@ -13,11 +13,13 @@
  * -----
  * `getAttachmentDirectionOverride()` returns the current override (or
  * `null` if unset).  It is always shipped — the read site in
- * `BoardMessageBus.attach-cards` simply reads `null` in production where
- * nothing can call the setter (the setter is exposed via `__ctTest`,
- * which is dev/E2E-build only — see `app/src/dev/ctTest.ts` and
- * `app/src/main.tsx`).  When `null`, the override path is dead and the
- * behavior is identical to today.
+ * `attachmentLayout.resolveEffectiveAttachmentLayout` simply reads `null`
+ * in production where nothing inside the shipped app calls the setter.
+ * The setter is exposed via `__ctDevTools.setAttachmentDirection`, which
+ * is reachable from any build (DEV or production-deployed PR previews)
+ * but is only invoked manually from the developer console — see
+ * `app/src/dev/ctDevTools.ts` and `app/src/main.tsx`.  When `null`, the
+ * override path is dead and behavior is identical to today.
  *
  * `setAttachmentDirectionOverride(dir | null)` writes; `null` clears.
  *

--- a/app/src/dev/attachmentOverride.ts
+++ b/app/src/dev/attachmentOverride.ts
@@ -1,0 +1,49 @@
+/**
+ * Dev/test-only attachment direction override.
+ *
+ * Module-level state that lets a test (or dev console) force the
+ * card-on-card attachment direction regardless of what the active plugin
+ * declares.  Used to lock in the full pipeline
+ * `plugin manifest -> BoardMessageBus -> attachCards ->
+ *  computeAttachmentPositions -> _pos` for non-default directions, since
+ * no shipped plugin currently sets a non-default `attachmentLayout.direction`
+ * (epic ct-2ie shipped 8-direction support but no plugin uses it).
+ *
+ * Shape
+ * -----
+ * `getAttachmentDirectionOverride()` returns the current override (or
+ * `null` if unset).  It is always shipped — the read site in
+ * `BoardMessageBus.attach-cards` simply reads `null` in production where
+ * nothing can call the setter (the setter is exposed via `__ctTest`,
+ * which is dev/E2E-build only — see `app/src/dev/ctTest.ts` and
+ * `app/src/main.tsx`).  When `null`, the override path is dead and the
+ * behavior is identical to today.
+ *
+ * `setAttachmentDirectionOverride(dir | null)` writes; `null` clears.
+ *
+ * `__resetAttachmentOverrideForTests()` is a back-door for unit tests so
+ * each `it(...)` starts from a known clean state.  Mirrors the
+ * `__resetCtDevToolsForTests()` helper in `ctDevTools.ts`.
+ */
+
+import type { AttachmentDirection } from '@cardtable2/shared';
+
+let override: AttachmentDirection | null = null;
+
+export function getAttachmentDirectionOverride(): AttachmentDirection | null {
+  return override;
+}
+
+export function setAttachmentDirectionOverride(
+  dir: AttachmentDirection | null,
+): void {
+  override = dir;
+}
+
+/**
+ * Test-only helper to reset module state between tests.  Not part of the
+ * public surface.
+ */
+export function __resetAttachmentOverrideForTests(): void {
+  override = null;
+}

--- a/app/src/dev/ctDevTools.ts
+++ b/app/src/dev/ctDevTools.ts
@@ -29,6 +29,9 @@
  * local persistence only.
  */
 
+import type { AttachmentDirection } from '@cardtable2/shared';
+import { setAttachmentDirectionOverride } from './attachmentOverride';
+
 const DB_PREFIX = 'cardtable-';
 
 /**
@@ -69,6 +72,22 @@ export interface CtDevToolsApi {
    *   `cardtable-` prefix internally.
    */
   clearTable(tableId: string): Promise<void>;
+
+  /**
+   * Force the card-on-card attachment direction for any subsequent
+   * `attach-cards` operation, regardless of the active plugin's
+   * `attachmentLayout.direction`.  Pass `null` to clear the override and
+   * restore plugin/default behavior.
+   *
+   * Lives on `__ctDevTools` (not `__ctTest`) so it is reachable from
+   * deployed PR/preview builds — manual verification of non-default
+   * directions is the entire reason the override exists, and no shipped
+   * plugin currently sets a non-default `direction`.  See ct-t1c.
+   *
+   * The override is read inside `BoardMessageBus`'s `attach-cards`
+   * handler — see `app/src/components/Board/BoardMessageBus.ts`.
+   */
+  setAttachmentDirection(dir: AttachmentDirection | null): void;
 }
 
 /**
@@ -183,6 +202,19 @@ export function createCtDevToolsApi(): CtDevToolsApi {
         '[ctDevTools] RELOAD THE PAGE to get a clean in-memory store ' +
           '— the current YjsStore is now divorced from persistence.',
       );
+    },
+
+    setAttachmentDirection(dir) {
+      setAttachmentDirectionOverride(dir);
+      if (dir === null) {
+        console.log(
+          '[ctDevTools] attachment direction override cleared — plugin/default behavior restored.',
+        );
+      } else {
+        console.log(
+          `[ctDevTools] attachment direction override set to "${dir}" — next attach-cards operation will use this direction regardless of plugin config.`,
+        );
+      }
     },
   };
 }

--- a/app/src/dev/ctTest.ts
+++ b/app/src/dev/ctTest.ts
@@ -38,9 +38,6 @@
  * original dispatch pattern this mirrors.
  */
 
-import type { AttachmentDirection } from '@cardtable2/shared';
-import { setAttachmentDirectionOverride } from './attachmentOverride';
-
 export interface WorldPoint {
   x: number;
   y: number;
@@ -120,28 +117,6 @@ export interface CtTestApi {
     canvas: ViewportPoint;
     viewport: ViewportPoint;
   }>;
-
-  /**
-   * Force the card-on-card attachment direction for any subsequent
-   * `attach-cards` operation, regardless of the active plugin's
-   * `attachmentLayout.direction`.  Pass `null` to clear the override and
-   * restore the plugin/default behavior.
-   *
-   * This exists so an E2E (or a manual MCP session) can exercise the
-   * full attach pipeline for non-default directions — no shipped plugin
-   * currently sets `direction` to a non-default value, so the only way
-   * to lock in regression coverage for the path
-   * `plugin manifest -> BoardMessageBus -> attachCards ->
-   *  computeAttachmentPositions -> _pos` for, say, `'top-right'` is via
-   * this dev override (see ct-t1c).
-   *
-   * The override is read inside `BoardMessageBus`'s `attach-cards`
-   * handler — see `app/src/components/Board/BoardMessageBus.ts`.  In
-   * production this setter is unreachable (the whole `__ctTest` API is
-   * gated behind `import.meta.env.DEV`/`VITE_E2E` in `installCtTest`),
-   * so the read site sees `null` and the override path is dead code.
-   */
-  setAttachmentDirection(dir: AttachmentDirection | null): void;
 }
 
 const DEFAULT_DRAG_STEPS = 10;
@@ -323,10 +298,6 @@ export function createCtTestApi(): CtTestApi {
         ...opts,
         buttons: opts.buttons ?? 0,
       });
-    },
-
-    setAttachmentDirection(dir) {
-      setAttachmentDirectionOverride(dir);
     },
 
     probeObjects(limit = 10) {

--- a/app/src/dev/ctTest.ts
+++ b/app/src/dev/ctTest.ts
@@ -38,6 +38,9 @@
  * original dispatch pattern this mirrors.
  */
 
+import type { AttachmentDirection } from '@cardtable2/shared';
+import { setAttachmentDirectionOverride } from './attachmentOverride';
+
 export interface WorldPoint {
   x: number;
   y: number;
@@ -117,6 +120,28 @@ export interface CtTestApi {
     canvas: ViewportPoint;
     viewport: ViewportPoint;
   }>;
+
+  /**
+   * Force the card-on-card attachment direction for any subsequent
+   * `attach-cards` operation, regardless of the active plugin's
+   * `attachmentLayout.direction`.  Pass `null` to clear the override and
+   * restore the plugin/default behavior.
+   *
+   * This exists so an E2E (or a manual MCP session) can exercise the
+   * full attach pipeline for non-default directions — no shipped plugin
+   * currently sets `direction` to a non-default value, so the only way
+   * to lock in regression coverage for the path
+   * `plugin manifest -> BoardMessageBus -> attachCards ->
+   *  computeAttachmentPositions -> _pos` for, say, `'top-right'` is via
+   * this dev override (see ct-t1c).
+   *
+   * The override is read inside `BoardMessageBus`'s `attach-cards`
+   * handler — see `app/src/components/Board/BoardMessageBus.ts`.  In
+   * production this setter is unreachable (the whole `__ctTest` API is
+   * gated behind `import.meta.env.DEV`/`VITE_E2E` in `installCtTest`),
+   * so the read site sees `null` and the override path is dead code.
+   */
+  setAttachmentDirection(dir: AttachmentDirection | null): void;
 }
 
 const DEFAULT_DRAG_STEPS = 10;
@@ -298,6 +323,10 @@ export function createCtTestApi(): CtTestApi {
         ...opts,
         buttons: opts.buttons ?? 0,
       });
+    },
+
+    setAttachmentDirection(dir) {
+      setAttachmentDirectionOverride(dir);
     },
 
     probeObjects(limit = 10) {

--- a/app/src/store/attachmentLayout.test.ts
+++ b/app/src/store/attachmentLayout.test.ts
@@ -1,12 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   DEFAULT_ATTACHMENT_LAYOUT,
   type AssetPack,
   type AttachmentDirection,
   type AttachmentLayout,
+  type GameAssets,
 } from '@cardtable2/shared';
-import { computeAttachmentPositions } from './attachmentLayout';
+import {
+  computeAttachmentPositions,
+  resolveEffectiveAttachmentLayout,
+} from './attachmentLayout';
 import { STACK_HEIGHT, STACK_WIDTH } from '../renderer/objects/stack/constants';
+import {
+  setAttachmentDirectionOverride,
+  __resetAttachmentOverrideForTests,
+} from '../dev/attachmentOverride';
+import type { YjsStore } from './YjsStore';
 
 describe('computeAttachmentPositions', () => {
   const parentPos = { x: 100, y: 200, r: 0 };
@@ -321,5 +330,105 @@ describe('attachmentLayout: plugin config flow', () => {
 
     const resolved = resolveAttachmentLayout(packs);
     expect(resolved).toBe(first);
+  });
+});
+
+// ============================================================================
+// resolveEffectiveAttachmentLayout: single source of truth for the layout
+// that initial-attach AND parent-drag-follow paths both consume (ct-0b6).
+// ============================================================================
+
+describe('resolveEffectiveAttachmentLayout', () => {
+  function makeStore(
+    packs: Pick<AssetPack, 'attachmentLayout'>[] | null,
+  ): YjsStore {
+    return {
+      getGameAssets: () =>
+        packs === null ? undefined : ({ packs } as unknown as GameAssets),
+    } as unknown as YjsStore;
+  }
+
+  beforeEach(() => {
+    __resetAttachmentOverrideForTests();
+  });
+
+  it('returns the plugin layout when one is configured and no override is set', () => {
+    const layout: AttachmentLayout = {
+      direction: 'left',
+      revealFraction: 0.3,
+    };
+    const store = makeStore([{ attachmentLayout: layout }]);
+
+    expect(resolveEffectiveAttachmentLayout(store)).toBe(layout);
+  });
+
+  it('returns undefined when no plugin layout and no override (downstream callers fall back to DEFAULT_ATTACHMENT_LAYOUT inside attachCards/moveObjects)', () => {
+    const store = makeStore([{}]);
+    expect(resolveEffectiveAttachmentLayout(store)).toBeUndefined();
+  });
+
+  it('returns undefined when there are no game assets at all and no override', () => {
+    const store = makeStore(null);
+    expect(resolveEffectiveAttachmentLayout(store)).toBeUndefined();
+  });
+
+  it('overrides the direction on the plugin layout while preserving other fields', () => {
+    const layout: AttachmentLayout = {
+      direction: 'left',
+      revealFraction: 0.3,
+      maxBeforeCompress: 4,
+      parentOnTop: false,
+    };
+    const store = makeStore([{ attachmentLayout: layout }]);
+    setAttachmentDirectionOverride('top-right');
+
+    const resolved = resolveEffectiveAttachmentLayout(store);
+    expect(resolved).toEqual({
+      direction: 'top-right',
+      revealFraction: 0.3,
+      maxBeforeCompress: 4,
+      parentOnTop: false,
+    });
+    // Must be a fresh object — must not mutate the plugin's layout.
+    expect(resolved).not.toBe(layout);
+    expect(layout.direction).toBe('left');
+  });
+
+  it('falls back to DEFAULT_ATTACHMENT_LAYOUT (with overridden direction) when no plugin layout exists', () => {
+    const store = makeStore([{}]);
+    setAttachmentDirectionOverride('bottom-right');
+
+    const resolved = resolveEffectiveAttachmentLayout(store);
+    expect(resolved).toEqual({
+      ...DEFAULT_ATTACHMENT_LAYOUT,
+      direction: 'bottom-right',
+    });
+  });
+
+  it('falls back to DEFAULT_ATTACHMENT_LAYOUT (with overridden direction) when game assets are missing', () => {
+    const store = makeStore(null);
+    setAttachmentDirectionOverride('top-left');
+
+    const resolved = resolveEffectiveAttachmentLayout(store);
+    expect(resolved).toEqual({
+      ...DEFAULT_ATTACHMENT_LAYOUT,
+      direction: 'top-left',
+    });
+  });
+
+  it('returns the plugin layout unchanged after the override is cleared', () => {
+    const layout: AttachmentLayout = {
+      direction: 'left',
+      revealFraction: 0.3,
+    };
+    const store = makeStore([{ attachmentLayout: layout }]);
+
+    setAttachmentDirectionOverride('top-right');
+    expect(resolveEffectiveAttachmentLayout(store)?.direction).toBe(
+      'top-right',
+    );
+
+    setAttachmentDirectionOverride(null);
+    expect(resolveEffectiveAttachmentLayout(store)).toBe(layout);
   });
 });

--- a/app/src/store/attachmentLayout.ts
+++ b/app/src/store/attachmentLayout.ts
@@ -1,5 +1,40 @@
 import type { Position, AttachmentLayout } from '@cardtable2/shared';
+import { DEFAULT_ATTACHMENT_LAYOUT } from '@cardtable2/shared';
 import { STACK_WIDTH, STACK_HEIGHT } from '../renderer/objects/stack/constants';
+import { getAttachmentDirectionOverride } from '../dev/attachmentOverride';
+import type { YjsStore } from './YjsStore';
+
+/**
+ * Resolve the attachment layout to use for a given store, applying any
+ * active dev override on top of the plugin's configured layout.
+ *
+ * Single source of truth for "which `AttachmentLayout` should the next
+ * attach-or-reposition operation use?" — both the `attach-cards` handler
+ * (initial placement) and the `objects-moved` handler (children
+ * following a parent drag) must consult this so the override sticks
+ * across both lifecycle phases (ct-0b6).  Without this consolidation,
+ * each new consumer of `attachmentLayout` had to remember to read the
+ * override, and the `objects-moved` path silently snapped children back
+ * to the plugin/default direction the moment the parent moved.
+ *
+ * In production builds the override is unreachable (the setter sits on
+ * `__ctDevTools.setAttachmentDirection`, but no code path inside the
+ * shipped app ever calls it), so this function reduces to the plain
+ * `gameAssets.packs.find(...)?.attachmentLayout` lookup.
+ */
+export function resolveEffectiveAttachmentLayout(
+  store: YjsStore,
+): AttachmentLayout | undefined {
+  const layout = store
+    .getGameAssets()
+    ?.packs.find((p) => p.attachmentLayout)?.attachmentLayout;
+  const overrideDir = getAttachmentDirectionOverride();
+  if (overrideDir === null) return layout;
+  return {
+    ...(layout ?? DEFAULT_ATTACHMENT_LAYOUT),
+    direction: overrideDir,
+  };
+}
 
 /**
  * Compute world positions for attached cards fanning out from a parent.


### PR DESCRIPTION
## Summary

- Adds a dev/E2E-only attachment direction override module (app/src/dev/attachmentOverride.ts) so the full pipeline plugin manifest -> BoardMessageBus -> attachCards -> computeAttachmentPositions -> _pos can be exercised for non-default directions. Epic ct-2ie shipped 8-direction support with thorough unit coverage of the math, but no shipped plugin currently sets a non-default attachmentLayout.direction so the runtime wiring went uncovered.
- Wires the override into BoardMessageBus.attach-cards by reading getAttachmentDirectionOverride() after resolving the plugin layout, then spreading {direction: override} on top of {layout ?? DEFAULT_ATTACHMENT_LAYOUT}. Behavior is identical to today when the override is null.
- Exposes the setter on the existing dev/E2E-only window.__ctTest API (CtTestApi.setAttachmentDirection(dir | null)), already gated behind import.meta.env.DEV / VITE_E2E in main.tsx — no extra production gating needed.
- New E2E spec app/e2e/attachment-layout.spec.ts covers a corner direction (top-right) and the cleared/default fallback (bottom). Both tests pass locally (3.7s each).
- Unit tests for the override module covering set/get/clear/round-trip across all 8 directions.

## Stacking note

This PR stacks on #102 (feature/attach-layout-8-directions, the 8-direction attachment work). It targets that branch as its base — once #102 merges to main, this branch should rebase onto main before merging.

## Discovered work

- ct-0b6 (related): Investigation bead — the override is read in BoardMessageBus.attach-cards but NOT in the objects-moved handler. After attaching with an override, moving the parent recomputes child positions using the plugin/default direction, which is asymmetric. Out of scope for ct-t1c (spec was attach-cards only, and the E2E doesn't move post-attach), but worth resolving so manual MCP verification doesn't see surprising behavior.

## Test plan

- [x] pnpm run typecheck (app)
- [x] pnpm run lint (app)
- [x] pnpm run test (1069 unit tests pass)
- [x] pnpm exec playwright test e2e/attachment-layout.spec.ts (2/2 pass)
- [ ] Smoke: open http://localhost:3000/dev/table/manual, run window.__ctTest.setAttachmentDirection('top-right') in console, drag one stack onto another with Alt held, verify child fans to upper-right
- [ ] Smoke: clear override (window.__ctTest.setAttachmentDirection(null)) and re-attach, verify default bottom placement

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>