### PR TITLE
feat(content): plugin-defined orientation rules (ct-3hi)

### DIFF
--- a/app/src/components/CardPreview.test.tsx
+++ b/app/src/components/CardPreview.test.tsx
@@ -10,7 +10,12 @@ import {
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { CardPreview } from './CardPreview';
-import type { Card, CardType, GameAssets } from '@cardtable2/shared';
+import type {
+  Card,
+  CardType,
+  GameAssets,
+  OrientationRule,
+} from '@cardtable2/shared';
 
 // Mock the useImage hook to control image loading
 vi.mock('use-image', () => ({
@@ -21,6 +26,7 @@ describe('CardPreview', () => {
   const createGameAssets = (
     cardTypes: Record<string, CardType> = {},
     cards: Record<string, Card> = {},
+    orientationRules: OrientationRule[] = [],
   ): GameAssets => ({
     packs: [],
     cardTypes,
@@ -33,6 +39,7 @@ describe('CardPreview', () => {
     statusTypes: {},
     modifierStats: {},
     iconTypes: {},
+    orientationRules,
   });
 
   const mockOnClose = vi.fn();
@@ -303,13 +310,14 @@ describe('CardPreview', () => {
 
     it('swaps dimensions for landscape cards', () => {
       const gameAssets = createGameAssets(
-        { villain: { orientation: 'landscape' } },
+        {},
         {
           rhino: {
             type: 'villain',
             face: 'rhino.jpg',
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
       render(
@@ -330,13 +338,14 @@ describe('CardPreview', () => {
     it('applies rotation transform when image orientation does not match metadata', () => {
       // Landscape metadata but portrait image (300x400) -> should rotate
       const gameAssets = createGameAssets(
-        { villain: { orientation: 'landscape' } },
+        {},
         {
           rhino: {
             type: 'villain',
             face: 'rhino.jpg',
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
       // Mock portrait image that doesn't match landscape metadata
@@ -360,13 +369,14 @@ describe('CardPreview', () => {
     it('does not apply rotation when rotationEnabled is false', () => {
       // Landscape metadata but portrait image -> would rotate, but rotationEnabled is false
       const gameAssets = createGameAssets(
-        { villain: { orientation: 'landscape' } },
+        {},
         {
           rhino: {
             type: 'villain',
             face: 'rhino.jpg',
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
       // Mock portrait image that doesn't match landscape metadata
@@ -390,13 +400,14 @@ describe('CardPreview', () => {
     it('does not apply rotation when image matches metadata orientation', () => {
       // Portrait metadata and portrait image -> no rotation needed
       const gameAssets = createGameAssets(
-        { hero: { orientation: 'portrait' } },
+        {},
         {
           spiderman: {
             type: 'hero',
             face: 'spiderman.jpg',
           },
         },
+        [{ match: { type: 'hero' }, orientation: 'portrait' }],
       );
 
       // Mock portrait image that matches portrait metadata
@@ -420,13 +431,14 @@ describe('CardPreview', () => {
     it('does not apply rotation for landscape image with landscape metadata', () => {
       // Landscape metadata and landscape image -> no rotation needed
       const gameAssets = createGameAssets(
-        { villain: { orientation: 'landscape' } },
+        {},
         {
           rhino: {
             type: 'villain',
             face: 'rhino.jpg',
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
       // Mock landscape image that matches landscape metadata

--- a/app/src/content/loader.ts
+++ b/app/src/content/loader.ts
@@ -285,18 +285,39 @@ export function mergeAssetPacks(
     statusTypes: {},
     modifierStats: {},
     iconTypes: {},
+    orientationRules: [],
   };
+
+  // Track which packs still set the deprecated cardType.orientation field so we
+  // can emit a single warning per merge call (one entry per offending pack).
+  const deprecatedOrientationPacks: string[] = [];
 
   // Merge each pack in order (later packs override earlier ones)
   // For cards and cardTypes, create new objects with resolved URLs (no mutation)
   for (const pack of packs) {
     // Merge cardTypes with URL resolution
     if (pack.cardTypes) {
+      let packHasDeprecatedOrientation = false;
       for (const [typeCode, cardType] of Object.entries(pack.cardTypes)) {
+        if (cardType.orientation !== undefined) {
+          packHasDeprecatedOrientation = true;
+        }
         merged.cardTypes[typeCode] = cardType.back
           ? { ...cardType, back: resolveAssetUrl(cardType.back, pack.baseUrl) }
           : cardType;
       }
+      if (packHasDeprecatedOrientation) {
+        deprecatedOrientationPacks.push(pack.id);
+      }
+    }
+
+    // Merge orientation rules (pack load order is preserved; first match wins
+    // at lookup time, so earlier packs take precedence over later ones).
+    if (pack.orientationRules && pack.orientationRules.length > 0) {
+      // merged.orientationRules is initialized to [] above; the optional `?`
+      // on the type is a backwards-compat convenience for callers, not a real
+      // possibility here.
+      (merged.orientationRules ??= []).push(...pack.orientationRules);
     }
 
     // Merge cards with URL resolution
@@ -358,6 +379,17 @@ export function mergeAssetPacks(
         };
       }
     }
+  }
+
+  // Deprecation: cardType.orientation is no longer read by the runtime —
+  // plugins must migrate to `orientationRules`. Warn once per pack-load with
+  // the offending pack ids so the plugin author sees an actionable message.
+  if (deprecatedOrientationPacks.length > 0) {
+    console.warn(
+      `[Loader] cardType.orientation is deprecated and ignored by the runtime. ` +
+        `Migrate to AssetPack.orientationRules (e.g. { match: { type: 'main_scheme' }, orientation: 'landscape' }). ` +
+        `Affected pack(s): ${deprecatedOrientationPacks.join(', ')}.`,
+    );
   }
 
   return merged;

--- a/app/src/content/loader.ts
+++ b/app/src/content/loader.ts
@@ -288,26 +288,15 @@ export function mergeAssetPacks(
     orientationRules: [],
   };
 
-  // Track which packs still set the deprecated cardType.orientation field so we
-  // can emit a single warning per merge call (one entry per offending pack).
-  const deprecatedOrientationPacks: string[] = [];
-
   // Merge each pack in order (later packs override earlier ones)
   // For cards and cardTypes, create new objects with resolved URLs (no mutation)
   for (const pack of packs) {
     // Merge cardTypes with URL resolution
     if (pack.cardTypes) {
-      let packHasDeprecatedOrientation = false;
       for (const [typeCode, cardType] of Object.entries(pack.cardTypes)) {
-        if (cardType.orientation !== undefined) {
-          packHasDeprecatedOrientation = true;
-        }
         merged.cardTypes[typeCode] = cardType.back
           ? { ...cardType, back: resolveAssetUrl(cardType.back, pack.baseUrl) }
           : cardType;
-      }
-      if (packHasDeprecatedOrientation) {
-        deprecatedOrientationPacks.push(pack.id);
       }
     }
 
@@ -379,17 +368,6 @@ export function mergeAssetPacks(
         };
       }
     }
-  }
-
-  // Deprecation: cardType.orientation is no longer read by the runtime —
-  // plugins must migrate to `orientationRules`. Warn once per pack-load with
-  // the offending pack ids so the plugin author sees an actionable message.
-  if (deprecatedOrientationPacks.length > 0) {
-    console.warn(
-      `[Loader] cardType.orientation is deprecated and ignored by the runtime. ` +
-        `Migrate to AssetPack.orientationRules (e.g. { match: { type: 'main_scheme' }, orientation: 'landscape' }). ` +
-        `Affected pack(s): ${deprecatedOrientationPacks.join(', ')}.`,
-    );
   }
 
   return merged;

--- a/app/src/content/utils.test.ts
+++ b/app/src/content/utils.test.ts
@@ -1,26 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import { getCardOrientation, getCardOrientationByCode } from './utils';
-import type { Card, CardType, GameAssets } from '@cardtable2/shared';
+import type {
+  Card,
+  CardType,
+  GameAssets,
+  OrientationRule,
+} from '@cardtable2/shared';
+
+const createGameAssets = (
+  cardTypes: Record<string, CardType> = {},
+  cards: Record<string, Card> = {},
+  orientationRules: OrientationRule[] = [],
+): GameAssets => ({
+  packs: [],
+  cardTypes,
+  cards,
+  cardSets: {},
+  tokens: {},
+  counters: {},
+  mats: {},
+  tokenTypes: {},
+  statusTypes: {},
+  modifierStats: {},
+  iconTypes: {},
+  orientationRules,
+});
 
 describe('getCardOrientation', () => {
-  const createGameAssets = (
-    cardTypes: Record<string, CardType> = {},
-    cards: Record<string, Card> = {},
-  ): GameAssets => ({
-    packs: [],
-    cardTypes,
-    cards,
-    cardSets: {},
-    tokens: {},
-    counters: {},
-    mats: {},
-    tokenTypes: {},
-    statusTypes: {},
-    modifierStats: {},
-    iconTypes: {},
-  });
-
-  describe('Card-level override', () => {
+  describe('Card-level override (layer 1)', () => {
     it('returns landscape when card has explicit landscape orientation', () => {
       const gameAssets = createGameAssets(
         {},
@@ -33,11 +40,9 @@ describe('getCardOrientation', () => {
         },
       );
 
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
+      expect(getCardOrientation(gameAssets.cards['testCard'], gameAssets)).toBe(
+        'landscape',
       );
-      expect(orientation).toBe('landscape');
     });
 
     it('returns portrait when card has explicit portrait orientation', () => {
@@ -52,351 +57,374 @@ describe('getCardOrientation', () => {
         },
       );
 
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-
-    it('overrides cardType orientation with card-level landscape', () => {
-      const gameAssets = createGameAssets(
-        {
-          hero: { orientation: 'portrait' },
-        },
-        {
-          testCard: {
-            type: 'hero',
-            face: 'face.jpg',
-            orientation: 'landscape', // Override type
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('landscape');
-    });
-
-    it('overrides cardType orientation with card-level portrait', () => {
-      const gameAssets = createGameAssets(
-        {
-          villain: { orientation: 'landscape' },
-        },
-        {
-          testCard: {
-            type: 'villain',
-            face: 'face.jpg',
-            orientation: 'portrait', // Override type
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-  });
-
-  describe('CardType default orientation', () => {
-    it('returns landscape from cardType when card has no orientation', () => {
-      const gameAssets = createGameAssets(
-        {
-          villain: { orientation: 'landscape' },
-        },
-        {
-          testCard: {
-            type: 'villain',
-            face: 'face.jpg',
-            // No card-level orientation
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('landscape');
-    });
-
-    it('returns portrait from cardType when card has no orientation', () => {
-      const gameAssets = createGameAssets(
-        {
-          hero: { orientation: 'portrait' },
-        },
-        {
-          testCard: {
-            type: 'hero',
-            face: 'face.jpg',
-            // No card-level orientation
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-
-    it('uses cardType orientation when different cards share the same type', () => {
-      const gameAssets = createGameAssets(
-        {
-          villain: { orientation: 'landscape' },
-        },
-        {
-          rhino: { type: 'villain', face: 'rhino.jpg' },
-          klaw: { type: 'villain', face: 'klaw.jpg' },
-          ultron: { type: 'villain', face: 'ultron.jpg' },
-        },
-      );
-
-      expect(getCardOrientation(gameAssets.cards['rhino'], gameAssets)).toBe(
-        'landscape',
-      );
-      expect(getCardOrientation(gameAssets.cards['klaw'], gameAssets)).toBe(
-        'landscape',
-      );
-      expect(getCardOrientation(gameAssets.cards['ultron'], gameAssets)).toBe(
-        'landscape',
+      expect(getCardOrientation(gameAssets.cards['testCard'], gameAssets)).toBe(
+        'portrait',
       );
     });
-  });
 
-  describe('Default to portrait', () => {
-    it('returns portrait when card and cardType have no orientation', () => {
-      const gameAssets = createGameAssets(
-        {
-          hero: {}, // No orientation
-        },
-        {
-          testCard: {
-            type: 'hero',
-            face: 'face.jpg',
-            // No orientation
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-
-    it('returns portrait when cardType does not exist', () => {
-      const gameAssets = createGameAssets(
-        {}, // No cardTypes defined
-        {
-          testCard: {
-            type: 'nonexistent',
-            face: 'face.jpg',
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-
-    it('returns portrait for empty gameAssets', () => {
-      const gameAssets = createGameAssets();
-      const card: Card = {
-        type: 'unknown',
-        face: 'face.jpg',
-      };
-
-      const orientation = getCardOrientation(card, gameAssets);
-      expect(orientation).toBe('portrait');
-    });
-  });
-
-  describe('Auto orientation handling', () => {
-    it('treats card-level auto as portrait (future enhancement)', () => {
+    it('card-level orientation overrides any matching rule', () => {
       const gameAssets = createGameAssets(
         {},
         {
           testCard: {
-            type: 'hero',
+            type: 'villain',
             face: 'face.jpg',
-            orientation: 'auto',
+            orientation: 'portrait', // Card-level wins
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
+      expect(getCardOrientation(gameAssets.cards['testCard'], gameAssets)).toBe(
+        'portrait',
       );
-      expect(orientation).toBe('portrait');
     });
 
-    it('treats cardType-level auto as portrait (future enhancement)', () => {
+    it('card-level auto falls through to rules', () => {
       const gameAssets = createGameAssets(
-        {
-          hero: { orientation: 'auto' },
-        },
-        {
-          testCard: {
-            type: 'hero',
-            face: 'face.jpg',
-          },
-        },
-      );
-
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
-      );
-      expect(orientation).toBe('portrait');
-    });
-
-    it('falls through auto to check cardType when card has auto', () => {
-      const gameAssets = createGameAssets(
-        {
-          villain: { orientation: 'landscape' },
-        },
+        {},
         {
           testCard: {
             type: 'villain',
             face: 'face.jpg',
-            orientation: 'auto', // Falls through to check type
+            orientation: 'auto', // 'auto' = no opinion
           },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
-      const orientation = getCardOrientation(
-        gameAssets.cards['testCard'],
-        gameAssets,
+      expect(getCardOrientation(gameAssets.cards['testCard'], gameAssets)).toBe(
+        'landscape',
       );
-      expect(orientation).toBe('landscape');
     });
   });
 
-  describe('Complex inheritance scenarios', () => {
-    it('handles mixed orientation across multiple card types', () => {
+  describe('Orientation rules (layer 2)', () => {
+    it('returns landscape when a single-key rule matches on type', () => {
       const gameAssets = createGameAssets(
-        {
-          villain: { orientation: 'landscape' },
-          hero: { orientation: 'portrait' },
-          ally: {}, // No orientation
-        },
+        {},
         {
           rhino: { type: 'villain', face: 'rhino.jpg' },
-          spiderman: { type: 'hero', face: 'spiderman.jpg' },
-          blackcat: { type: 'ally', face: 'blackcat.jpg' },
-          specialVillain: {
-            type: 'villain',
-            face: 'special.jpg',
-            orientation: 'portrait', // Override
-          },
         },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
       );
 
       expect(getCardOrientation(gameAssets.cards['rhino'], gameAssets)).toBe(
         'landscape',
       );
-      expect(
-        getCardOrientation(gameAssets.cards['spiderman'], gameAssets),
-      ).toBe('portrait');
-      expect(getCardOrientation(gameAssets.cards['blackcat'], gameAssets)).toBe(
+    });
+
+    it('returns portrait fallback when no rule matches', () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          ally: { type: 'ally', face: 'ally.jpg' },
+        },
+        [{ match: { type: 'villain' }, orientation: 'landscape' }],
+      );
+
+      expect(getCardOrientation(gameAssets.cards['ally'], gameAssets)).toBe(
         'portrait',
-      ); // Default
+      );
+    });
+
+    it('matches on a non-type field (typeCode)', () => {
+      // This is the motivating case from the spec: cards with type=encounter
+      // but typeCode=side_scheme should render landscape, while other encounter
+      // cards stay portrait.
+      const gameAssets = createGameAssets(
+        {},
+        {
+          sideScheme: {
+            type: 'encounter',
+            typeCode: 'side_scheme',
+            face: 'ss.jpg',
+          },
+          obligation: {
+            type: 'encounter',
+            typeCode: 'obligation',
+            face: 'ob.jpg',
+          },
+        },
+        [{ match: { typeCode: 'side_scheme' }, orientation: 'landscape' }],
+      );
+
       expect(
-        getCardOrientation(gameAssets.cards['specialVillain'], gameAssets),
-      ).toBe('portrait'); // Override
+        getCardOrientation(gameAssets.cards['sideScheme'], gameAssets),
+      ).toBe('landscape');
+      expect(
+        getCardOrientation(gameAssets.cards['obligation'], gameAssets),
+      ).toBe('portrait');
+    });
+
+    it('multi-key match: ALL keys must match (AND semantics)', () => {
+      const rules: OrientationRule[] = [
+        {
+          match: { type: 'encounter', setCode: 'rhino_nemesis' },
+          orientation: 'landscape',
+        },
+      ];
+      const gameAssets = createGameAssets(
+        {},
+        {
+          // both keys match — should be landscape
+          rhinoEnc: {
+            type: 'encounter',
+            setCode: 'rhino_nemesis',
+            face: 'r.jpg',
+          },
+          // only `type` matches — should fall through to portrait
+          klawEnc: {
+            type: 'encounter',
+            setCode: 'klaw_nemesis',
+            face: 'k.jpg',
+          },
+          // only `setCode` matches — should fall through to portrait
+          rhinoOther: {
+            type: 'ally',
+            setCode: 'rhino_nemesis',
+            face: 'ro.jpg',
+          },
+        },
+        rules,
+      );
+
+      expect(getCardOrientation(gameAssets.cards['rhinoEnc'], gameAssets)).toBe(
+        'landscape',
+      );
+      expect(getCardOrientation(gameAssets.cards['klawEnc'], gameAssets)).toBe(
+        'portrait',
+      );
+      expect(
+        getCardOrientation(gameAssets.cards['rhinoOther'], gameAssets),
+      ).toBe('portrait');
+    });
+
+    it('first-match-wins when multiple rules match the same card', () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          card: { type: 'encounter', typeCode: 'side_scheme', face: 'c.jpg' },
+        },
+        [
+          // First rule fires — even though the second rule would also match.
+          { match: { type: 'encounter' }, orientation: 'portrait' },
+          { match: { typeCode: 'side_scheme' }, orientation: 'landscape' },
+        ],
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'portrait',
+      );
+    });
+
+    it("rule with orientation='auto' falls through to the next rule", () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          card: { type: 'main_scheme', face: 'c.jpg' },
+        },
+        [
+          // First rule matches structurally but returns 'auto' = "no opinion".
+          { match: { type: 'main_scheme' }, orientation: 'auto' },
+          // The walk continues; this matches and wins.
+          { match: { type: 'main_scheme' }, orientation: 'landscape' },
+        ],
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'landscape',
+      );
+    });
+
+    it("rule with orientation='auto' and no later match falls back to portrait", () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          card: { type: 'main_scheme', face: 'c.jpg' },
+        },
+        [{ match: { type: 'main_scheme' }, orientation: 'auto' }],
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'portrait',
+      );
+    });
+
+    it('empty match object matches every card (catch-all rule)', () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          anyCard: { type: 'whatever', face: 'a.jpg' },
+        },
+        // A rule with no match keys is vacuously satisfied by any card.
+        [{ match: {}, orientation: 'landscape' }],
+      );
+
+      expect(getCardOrientation(gameAssets.cards['anyCard'], gameAssets)).toBe(
+        'landscape',
+      );
+    });
+  });
+
+  describe('Backwards compatibility / fallback (layer 3)', () => {
+    it('returns portrait when no rules block is supplied', () => {
+      // Plugins that have not migrated yet still get a sane default.
+      const gameAssets = createGameAssets(
+        {},
+        {
+          card: { type: 'hero', face: 'h.jpg' },
+        },
+        // empty orientationRules, simulating a pre-migration plugin
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'portrait',
+      );
+    });
+
+    it('IGNORES the deprecated cardType.orientation field', () => {
+      // The old cardType-keyed lookup is gone. A pre-migration plugin that
+      // still sets cardTypes.X.orientation gets portrait (the runtime warns
+      // separately via mergeAssetPacks; this test pins the resolver behavior).
+      const gameAssets = createGameAssets(
+        {
+          main_scheme: { orientation: 'landscape' }, // deprecated, ignored
+        },
+        {
+          card: { type: 'main_scheme', face: 'm.jpg' },
+        },
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'portrait',
+      );
+    });
+
+    it('returns portrait when card has no orientation and no rules match', () => {
+      const gameAssets = createGameAssets(
+        {},
+        {
+          card: { type: 'unknown', face: 'u.jpg' },
+        },
+      );
+
+      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
+        'portrait',
+      );
+    });
+  });
+
+  describe('Mixed scenarios', () => {
+    it('handles a realistic Marvel Champions migration: main_scheme + side_scheme', () => {
+      // Models the post-migration state of the MC plugin (mc-yta).
+      const rules: OrientationRule[] = [
+        { match: { typeCode: 'side_scheme' }, orientation: 'landscape' },
+        { match: { type: 'main_scheme' }, orientation: 'landscape' },
+      ];
+      const gameAssets = createGameAssets(
+        {},
+        {
+          mainScheme: { type: 'main_scheme', face: 'ms.jpg' },
+          sideScheme: {
+            type: 'encounter',
+            typeCode: 'side_scheme',
+            face: 'ss.jpg',
+          },
+          encounter: {
+            type: 'encounter',
+            typeCode: 'obligation',
+            face: 'ob.jpg',
+          },
+          hero: { type: 'hero', face: 'h.jpg' },
+          // Per-card override beats every rule
+          weirdHero: {
+            type: 'hero',
+            face: 'wh.jpg',
+            orientation: 'landscape',
+          },
+        },
+        rules,
+      );
+
+      expect(
+        getCardOrientation(gameAssets.cards['mainScheme'], gameAssets),
+      ).toBe('landscape');
+      expect(
+        getCardOrientation(gameAssets.cards['sideScheme'], gameAssets),
+      ).toBe('landscape');
+      expect(
+        getCardOrientation(gameAssets.cards['encounter'], gameAssets),
+      ).toBe('portrait');
+      expect(getCardOrientation(gameAssets.cards['hero'], gameAssets)).toBe(
+        'portrait',
+      );
+      expect(
+        getCardOrientation(gameAssets.cards['weirdHero'], gameAssets),
+      ).toBe('landscape');
     });
   });
 });
 
 describe('getCardOrientationByCode', () => {
-  const createGameAssets = (
-    cardTypes: Record<string, CardType> = {},
-    cards: Record<string, Card> = {},
-  ): GameAssets => ({
-    packs: [],
-    cardTypes,
-    cards,
-    cardSets: {},
-    tokens: {},
-    counters: {},
-    mats: {},
-    tokenTypes: {},
-    statusTypes: {},
-    modifierStats: {},
-    iconTypes: {},
-  });
-
-  it('returns landscape for card with landscape orientation', () => {
+  it('returns landscape for a card whose type matches a landscape rule', () => {
     const gameAssets = createGameAssets(
-      {
-        villain: { orientation: 'landscape' },
-      },
+      {},
       {
         mc01_rhino: { type: 'villain', face: 'rhino.jpg' },
       },
+      [{ match: { type: 'villain' }, orientation: 'landscape' }],
     );
 
-    const orientation = getCardOrientationByCode('mc01_rhino', gameAssets);
-    expect(orientation).toBe('landscape');
+    expect(getCardOrientationByCode('mc01_rhino', gameAssets)).toBe(
+      'landscape',
+    );
   });
 
-  it('returns portrait for card with portrait orientation', () => {
+  it('returns portrait for a card with no matching rule', () => {
     const gameAssets = createGameAssets(
-      {
-        hero: { orientation: 'portrait' },
-      },
+      {},
       {
         mc01_spiderman: { type: 'hero', face: 'spiderman.jpg' },
       },
+      [{ match: { type: 'villain' }, orientation: 'landscape' }],
     );
 
-    const orientation = getCardOrientationByCode('mc01_spiderman', gameAssets);
-    expect(orientation).toBe('portrait');
+    expect(getCardOrientationByCode('mc01_spiderman', gameAssets)).toBe(
+      'portrait',
+    );
   });
 
   it('returns null when card code does not exist', () => {
     const gameAssets = createGameAssets();
-
-    const orientation = getCardOrientationByCode('nonexistent', gameAssets);
-    expect(orientation).toBeNull();
+    expect(getCardOrientationByCode('nonexistent', gameAssets)).toBeNull();
   });
 
-  it('returns portrait by default when card has no orientation', () => {
+  it('returns portrait when no rules block is supplied', () => {
     const gameAssets = createGameAssets(
-      {
-        hero: {}, // No orientation
-      },
+      {},
       {
         mc01_spiderman: { type: 'hero', face: 'spiderman.jpg' },
       },
     );
 
-    const orientation = getCardOrientationByCode('mc01_spiderman', gameAssets);
-    expect(orientation).toBe('portrait');
+    expect(getCardOrientationByCode('mc01_spiderman', gameAssets)).toBe(
+      'portrait',
+    );
   });
 
-  it('handles multiple lookups correctly', () => {
+  it('handles multiple lookups consistently', () => {
     const gameAssets = createGameAssets(
-      {
-        villain: { orientation: 'landscape' },
-        hero: { orientation: 'portrait' },
-      },
+      {},
       {
         villain1: { type: 'villain', face: 'v1.jpg' },
         villain2: { type: 'villain', face: 'v2.jpg' },
         hero1: { type: 'hero', face: 'h1.jpg' },
       },
+      [
+        { match: { type: 'villain' }, orientation: 'landscape' },
+        { match: { type: 'hero' }, orientation: 'portrait' },
+      ],
     );
 
     expect(getCardOrientationByCode('villain1', gameAssets)).toBe('landscape');

--- a/app/src/content/utils.test.ts
+++ b/app/src/content/utils.test.ts
@@ -283,24 +283,6 @@ describe('getCardOrientation', () => {
       );
     });
 
-    it('IGNORES the deprecated cardType.orientation field', () => {
-      // The old cardType-keyed lookup is gone. A pre-migration plugin that
-      // still sets cardTypes.X.orientation gets portrait (the runtime warns
-      // separately via mergeAssetPacks; this test pins the resolver behavior).
-      const gameAssets = createGameAssets(
-        {
-          main_scheme: { orientation: 'landscape' }, // deprecated, ignored
-        },
-        {
-          card: { type: 'main_scheme', face: 'm.jpg' },
-        },
-      );
-
-      expect(getCardOrientation(gameAssets.cards['card'], gameAssets)).toBe(
-        'portrait',
-      );
-    });
-
     it('returns portrait when card has no orientation and no rules match', () => {
       const gameAssets = createGameAssets(
         {},

--- a/app/src/content/utils.ts
+++ b/app/src/content/utils.ts
@@ -1,44 +1,78 @@
-import type { Card, GameAssets } from '@cardtable2/shared';
+import type { Card, GameAssets, OrientationRule } from '@cardtable2/shared';
 
 /**
- * Get the display orientation for a card
+ * Get the display orientation for a card.
  *
- * Follows inheritance chain:
- * 1. Check card.orientation (explicit override)
- * 2. Check cardType.orientation (type default)
- * 3. Default to 'portrait'
+ * Resolution order:
+ *  1. `card.orientation` — explicit per-card override (highest priority).
+ *     A value of `'auto'` is treated as "no opinion" and falls through to (2).
+ *  2. `gameAssets.orientationRules` — plugin-declared rules walked in order.
+ *     The first rule whose `match` object's keys ALL match this card's fields
+ *     wins. A rule resolving to `'auto'` is treated as "no opinion" for that
+ *     rule and the walk continues to the next rule.
+ *  3. Fallback `'portrait'`.
  *
- * Note: 'auto' is treated as 'portrait' for now.
- * Future enhancement: detect from image aspect ratio.
+ * The cardType-keyed orientation lookup that previously sat between (1) and
+ * (3) has been removed. Plugin authors migrate any `cardTypes.X.orientation`
+ * setting to a rule like `{ match: { type: 'X' }, orientation: '...' }`.
  *
- * @param card - Card data from GameAssets
- * @param gameAssets - All loaded game assets
- * @returns 'portrait' or 'landscape'
- *
- * @example
- * ```typescript
- * const orientation = getCardOrientation(card, gameAssets);
- * // Returns 'landscape' if card or its type specifies landscape
- * // Otherwise returns 'portrait'
- * ```
+ * Note: `'auto'` is not yet auto-detected from image aspect ratio; it simply
+ * means "this layer has no opinion, defer to the next layer".
  */
 export function getCardOrientation(
   card: Card,
   gameAssets: GameAssets,
 ): 'portrait' | 'landscape' {
-  // Check card-level override (explicit)
+  // Layer 1 — per-card override
   if (card.orientation && card.orientation !== 'auto') {
     return card.orientation;
   }
 
-  // Check card type default
-  const cardType = gameAssets.cardTypes[card.type];
-  if (cardType?.orientation && cardType.orientation !== 'auto') {
-    return cardType.orientation;
+  // Layer 2 — plugin-declared orientation rules. Walk in declared order; the
+  // first rule whose match object satisfies the card AND resolves to a
+  // concrete orientation wins. A rule with `orientation: 'auto'` is treated
+  // as "no opinion" — even when the match object fires, the walk continues
+  // to the next rule (mirroring the per-card 'auto' fallthrough).
+  const resolved = walkOrientationRules(card, gameAssets.orientationRules);
+  if (resolved) {
+    return resolved;
   }
 
-  // Default to portrait
+  // Layer 3 — fallback
   return 'portrait';
+}
+
+/**
+ * Walk `rules` in declared order; return the orientation of the first rule
+ * whose `match` object is satisfied by `card` AND whose `orientation` is a
+ * concrete value (`'portrait'` or `'landscape'`). Rules resolving to `'auto'`
+ * are treated as "no opinion" — the walk skips them even when they match
+ * structurally. Returns `null` when no rule produces a concrete answer.
+ */
+function walkOrientationRules(
+  card: Card,
+  rules: OrientationRule[] | undefined,
+): 'portrait' | 'landscape' | null {
+  if (!rules || rules.length === 0) {
+    return null;
+  }
+  // Treat the card as a plain field-name → value lookup. Card field values
+  // we match on are strings (type, typeCode, setCode, etc.); rule values are
+  // declared `Record<string, string>`, so a strict equality check is correct.
+  const cardFields = card as unknown as Record<string, unknown>;
+  for (const rule of rules) {
+    let allMatch = true;
+    for (const [field, expected] of Object.entries(rule.match)) {
+      if (cardFields[field] !== expected) {
+        allMatch = false;
+        break;
+      }
+    }
+    if (allMatch && rule.orientation !== 'auto') {
+      return rule.orientation;
+    }
+  }
+  return null;
 }
 
 /**
@@ -54,7 +88,7 @@ export function getCardOrientation(
  * @example
  * ```typescript
  * const orientation = getCardOrientationByCode('mc01_rhino', gameAssets);
- * // Returns 'landscape' if rhino card or villain type is landscape
+ * // Returns 'landscape' if a rule matches the rhino card, else 'portrait'
  * ```
  */
 export function getCardOrientationByCode(

--- a/app/src/content/utils.ts
+++ b/app/src/content/utils.ts
@@ -12,10 +12,6 @@ import type { Card, GameAssets, OrientationRule } from '@cardtable2/shared';
  *     rule and the walk continues to the next rule.
  *  3. Fallback `'portrait'`.
  *
- * The cardType-keyed orientation lookup that previously sat between (1) and
- * (3) has been removed. Plugin authors migrate any `cardTypes.X.orientation`
- * setting to a rule like `{ match: { type: 'X' }, orientation: '...' }`.
- *
  * Note: `'auto'` is not yet auto-detected from image aspect ratio; it simply
  * means "this layer has no opinion, defer to the next layer".
  */

--- a/shared/schemas/ct-assets-v1.schema.json
+++ b/shared/schemas/ct-assets-v1.schema.json
@@ -57,11 +57,6 @@
               }
             ],
             "description": "Default size for all cards of this type (defaults to 'standard': 180x252px)"
-          },
-          "orientation": {
-            "type": "string",
-            "enum": ["portrait", "landscape", "auto"],
-            "description": "DEPRECATED. Ignored by the runtime — use top-level orientationRules instead. Retained on the schema for backwards compatibility while plugins migrate; a console warning is emitted on plugin load if this field is still set."
           }
         },
         "additionalProperties": false

--- a/shared/schemas/ct-assets-v1.schema.json
+++ b/shared/schemas/ct-assets-v1.schema.json
@@ -57,6 +57,11 @@
               }
             ],
             "description": "Default size for all cards of this type (defaults to 'standard': 180x252px)"
+          },
+          "orientation": {
+            "type": "string",
+            "enum": ["portrait", "landscape", "auto"],
+            "description": "DEPRECATED. Ignored by the runtime — use top-level orientationRules instead. Retained on the schema for backwards compatibility while plugins migrate; a console warning is emitted on plugin load if this field is still set."
           }
         },
         "additionalProperties": false
@@ -209,6 +214,29 @@
               }
             ],
             "description": "Mat size (defaults to 'playmat' if omitted: 1920x1080px)"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "orientationRules": {
+      "type": "array",
+      "description": "Plugin-declared orientation rules. Walked in declared order; the first rule whose match-object keys all match a given card returns its orientation. A rule resolving to 'auto' is treated as 'no opinion' and the walk continues to the next rule. Match field names can be any field on the Card object (type, typeCode, setCode, etc.).",
+      "items": {
+        "type": "object",
+        "required": ["match", "orientation"],
+        "properties": {
+          "match": {
+            "type": "object",
+            "description": "Card field-name -> expected-value pairs (AND-ed; all must match for the rule to fire).",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "orientation": {
+            "type": "string",
+            "enum": ["portrait", "landscape", "auto"],
+            "description": "Resolved orientation when this rule matches. 'auto' falls through to the next rule."
           }
         },
         "additionalProperties": false

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -28,10 +28,37 @@ export type MatSize =
 
 export type CardOrientation = 'portrait' | 'landscape' | 'auto';
 
+/**
+ * Plugin-declared rule mapping card metadata to a render orientation.
+ *
+ * The `match` object is a record of card field-name → expected-value;
+ * a card matches the rule only when ALL keys match (AND semantics).
+ * Match field names can be any field on the `Card` type — `type`, `typeCode`,
+ * `setCode`, etc. — letting plugins classify orientation more finely than the
+ * (deprecated) cardType-keyed lookup allowed.
+ *
+ * Runtime walks `gameAssets.orientationRules` in declared order; the first rule
+ * whose match-object satisfies the card returns its `orientation`. A rule with
+ * `orientation: 'auto'` is treated as "no opinion" — the walk continues to the
+ * next rule, matching the existing per-card 'auto' semantics.
+ */
+export interface OrientationRule {
+  match: Record<string, string>; // Card field-name → expected-value (AND-ed)
+  orientation: CardOrientation; // Resolved orientation (or 'auto' to skip)
+}
+
 export interface CardType {
   back?: string; // Default card back image URL
   size?: CardSize; // Default size for this card type
-  orientation?: CardOrientation; // Default orientation for this card type (defaults to 'portrait')
+  /**
+   * @deprecated Use `AssetPack.orientationRules` instead. The runtime no longer
+   * reads this field as of the orientation-rules migration; it is retained on
+   * the schema solely so existing plugins do not fail to load while they
+   * migrate. A one-time console warning is emitted on plugin load if this
+   * field is still set. Remove once all consuming plugins (notably
+   * cardtable-plugin-marvelchampions) have migrated.
+   */
+  orientation?: CardOrientation;
 }
 
 export interface Card {
@@ -161,6 +188,8 @@ export interface AssetPack {
   iconTypes?: Record<string, IconTypeDef>; // Icon types (key is icon type code)
   // Card-on-card attachment configuration
   attachmentLayout?: AttachmentLayout; // Default layout for card-on-card attachments
+  // Orientation rules — see OrientationRule for semantics
+  orientationRules?: OrientationRule[]; // Plugin-declared orientation rules (walked in order, first match wins)
 }
 
 // ============================================================================
@@ -356,6 +385,9 @@ export interface GameAssets {
   statusTypes: Record<string, StatusTypeDef>; // Merged status types
   modifierStats: Record<string, ModifierStatDef>; // Merged modifier stats
   iconTypes: Record<string, IconTypeDef>; // Merged icon types
+  // Orientation rules merged from all packs (pack load order is preserved; first match wins at lookup time).
+  // Optional so existing test fixtures and pre-migration callers stay valid; mergeAssetPacks always populates an array.
+  orientationRules?: OrientationRule[];
 }
 
 // ============================================================================

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -34,8 +34,7 @@ export type CardOrientation = 'portrait' | 'landscape' | 'auto';
  * The `match` object is a record of card field-name → expected-value;
  * a card matches the rule only when ALL keys match (AND semantics).
  * Match field names can be any field on the `Card` type — `type`, `typeCode`,
- * `setCode`, etc. — letting plugins classify orientation more finely than the
- * (deprecated) cardType-keyed lookup allowed.
+ * `setCode`, etc. — letting plugins classify orientation finely.
  *
  * Runtime walks `gameAssets.orientationRules` in declared order; the first rule
  * whose match-object satisfies the card returns its `orientation`. A rule with
@@ -50,15 +49,6 @@ export interface OrientationRule {
 export interface CardType {
   back?: string; // Default card back image URL
   size?: CardSize; // Default size for this card type
-  /**
-   * @deprecated Use `AssetPack.orientationRules` instead. The runtime no longer
-   * reads this field as of the orientation-rules migration; it is retained on
-   * the schema solely so existing plugins do not fail to load while they
-   * migrate. A one-time console warning is emitted on plugin load if this
-   * field is still set. Remove once all consuming plugins (notably
-   * cardtable-plugin-marvelchampions) have migrated.
-   */
-  orientation?: CardOrientation;
 }
 
 export interface Card {


### PR DESCRIPTION
## Summary

- Replaces the cardType-keyed orientation lookup in `getCardOrientation` with a plugin-declared `orientationRules` array. Each rule has a `match` object (field-name -> expected-value, AND-ed) and an `orientation`. The resolver walks rules in declared order; the first rule whose match satisfies the card AND resolves to a concrete orientation wins. Rules resolving to `'auto'` are skipped (mirroring per-card `'auto'` fallthrough).
- Unblocks finer-grained classification than `card.type` allows. Marvel Champions has cards with `type: 'encounter'` but `typeCode: 'side_scheme'` that should render landscape; today there is no way to express that. With this change, the plugin declares `{ match: { typeCode: 'side_scheme' }, orientation: 'landscape' }`.
- Hover preview (`Board.tsx`) and `CardPreview.tsx` already call `getCardOrientation`, so they pick up the new rules transitively (no call-site changes needed).

## Breaking change — `cardType.orientation` removed outright

`cardType.orientation` is **gone** from the type, the JSON schema, and the runtime. There is no deprecation warning, no transitional period — the field simply doesn't exist anymore. This is a greenfield project with no production users, so the cleaner final state wins over a transitional deprecation.

- TS type: the `orientation?` field has been deleted from `CardType` in `shared/src/content-types.ts`.
- JSON schema: the `orientation` property has been deleted from the cardType sub-schema in `shared/schemas/ct-assets-v1.schema.json`.
- Runtime: `mergeAssetPacks` no longer reads or warns about the field; `getCardOrientation` resolves only via `card.orientation` -> `orientationRules` -> `'portrait'` fallback.

## Cross-repo dependency

`cardtable-plugin-marvelchampions` currently sets `cardTypes.main_scheme.orientation: 'landscape'`. That setting will no longer typecheck against the new `CardType` shape, and the runtime ignores it regardless. The breaking change lands hard the moment this PR merges; MC `main_scheme` cards will render portrait until **mc-yta** ships in `cardtable-plugin-marvelchampions`. Coordinate the cutover. The MC migration should add an `orientationRules` block like:

```json
"orientationRules": [
  { "match": { "typeCode": "side_scheme" }, "orientation": "landscape" },
  { "match": { "type": "main_scheme" }, "orientation": "landscape" }
]
```

## Test plan

Quality gates run locally before push:

- [x] `pnpm run typecheck` (whole monorepo: shared + server + app)
- [x] `pnpm --filter app run test --run` — 1077 tests pass (includes 20 tests in `app/src/content/utils.test.ts` covering rule matched, rule not matched, multi-key AND, first-match-wins, `'auto'` fallthrough, empty match catch-all, no-rules-block backwards compat, and a realistic MC main_scheme + side_scheme migration scenario)
- [x] `pnpm --filter app run lint` — clean
- [x] `pnpm --filter shared run lint` — clean
- [x] `jq empty shared/schemas/ct-assets-v1.schema.json` — schema is valid JSON

Manual verification (once MC migrates via mc-yta):

- [ ] Load MC plugin, open a scenario with a main_scheme card, confirm it renders landscape after the migration.
- [ ] Load a side_scheme card and confirm it renders landscape (this is the new capability).
- [ ] Hover-preview a landscape card and confirm dimensions are swapped correctly (no rotation regression).

## Files changed

- `shared/src/content-types.ts` — adds `OrientationRule`, `AssetPack.orientationRules?`, `GameAssets.orientationRules?`; **removes `CardType.orientation`**.
- `shared/schemas/ct-assets-v1.schema.json` — documents new top-level `orientationRules`; **removes the `orientation` property from cardType**.
- `app/src/content/loader.ts` — merges per-pack `orientationRules` in load order. No deprecation warning — the field is gone from the type, so it can't be set.
- `app/src/content/utils.ts` — replaces cardType lookup with `walkOrientationRules`.
- `app/src/content/utils.test.ts` — rewritten to cover the rules-walk semantics.
- `app/src/components/CardPreview.test.tsx` — migrated 5 fixtures from `cardType.orientation` to `orientationRules`.

Generated with [Claude Code](https://claude.com/claude-code)