### PR TITLE
feat(content): resolve back_code for two-sided cards (ct-r1p)

### DIFF
--- a/app/src/components/Board.tsx
+++ b/app/src/components/Board.tsx
@@ -148,8 +148,15 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
     Array<(isAnimating: boolean) => void>
   >([]);
 
-  // Card preview state (hover mode)
-  const [previewCard, setPreviewCard] = useState<Card | null>(null);
+  // Card preview state (hover mode). Carries cardCode and faceUp so the
+  // preview component can resolve which side to render — see CardPreview.tsx
+  // (face-up shows .face; face-down shows the back via card.back / back_code,
+  // skipped entirely if the back is the generic cardType.back).
+  const [previewCard, setPreviewCard] = useState<{
+    card: Card;
+    cardCode: string;
+    faceUp: boolean;
+  } | null>(null);
   const [previewPosition, setPreviewPosition] = useState<{
     x: number;
     y: number;
@@ -164,9 +171,13 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
     }
   }, [isMenuOpen, isPhantomDragActive]);
 
-  // Modal preview state (mobile double-tap)
+  // Modal preview state (mobile double-tap). Same shape as hover preview.
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [modalPreviewCard, setModalPreviewCard] = useState<Card | null>(null);
+  const [modalPreviewCard, setModalPreviewCard] = useState<{
+    card: Card;
+    cardCode: string;
+    faceUp: boolean;
+  } | null>(null);
 
   // Custom hooks
   const { renderer, renderMode } = useRenderer('auto');
@@ -233,7 +244,7 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
 
   // Helper: Get card from stack object
   const getCardFromStack = useCallback(
-    (objectId: string): Card | null => {
+    (objectId: string): { card: Card; cardCode: string } | null => {
       const obj = storeRef.current.getObject(objectId);
 
       if (!obj) {
@@ -280,7 +291,7 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
         return null;
       }
 
-      return card;
+      return { card, cardCode: topCardCode };
     },
     [gameAssets],
   );
@@ -305,8 +316,8 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
         'cardScreenHeight=',
         cardScreenHeight,
       );
-      // If hover cleared or not face-up, hide preview
-      if (!objectId || !isFaceUp) {
+      // If hover cleared, hide preview
+      if (!objectId) {
         dbg('hover', 'Board.setHoveredObject -> CLEARING previewCard');
         setPreviewCard(null);
         setPreviewPosition(null);
@@ -320,10 +331,11 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
       }
 
       // Get the card using helper
-      const card = getCardFromStack(objectId);
-      if (!card || !gameAssets) {
+      const result = getCardFromStack(objectId);
+      if (!result || !gameAssets) {
         return;
       }
+      const { card, cardCode } = result;
 
       // Calculate preview dimensions based on card orientation
       const orientation = getCardOrientation(card, gameAssets);
@@ -379,21 +391,28 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
         objectId,
       );
       setPreviewPosition({ x, y });
-      setPreviewCard(card);
+      setPreviewCard({ card, cardCode, faceUp: isFaceUp });
     },
     [gameAssets, getCardFromStack, isPhantomDragActive],
   );
 
-  // Handle modal preview request from renderer (mobile double-tap)
+  // Handle modal preview request from renderer (mobile double-tap).
+  // The renderer's message only carries objectId, so faceUp is read from the
+  // store here. CardPreview/FullScreenCardPreview decide what to render based
+  // on faceUp + back resolution; if face-down with a default cardType.back
+  // they show nothing (consistent with hover behavior).
   const showCardPreviewModal = useCallback(
     (objectId: string) => {
-      // Get the card using helper
-      const card = getCardFromStack(objectId);
-      if (!card) {
+      const result = getCardFromStack(objectId);
+      if (!result) {
         return;
       }
-
-      setModalPreviewCard(card);
+      const obj = storeRef.current.getObject(objectId);
+      if (!obj || obj._kind !== ObjectKind.Stack) {
+        return;
+      }
+      const faceUp = (obj as StackObject)._faceUp ?? true;
+      setModalPreviewCard({ ...result, faceUp });
       setIsModalVisible(true);
     },
     [getCardFromStack],
@@ -729,7 +748,9 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
 
       {/* Card Preview - Hover Mode */}
       <CardPreview
-        card={previewCard}
+        card={previewCard?.card ?? null}
+        cardCode={previewCard?.cardCode ?? null}
+        faceUp={previewCard?.faceUp ?? true}
         gameAssets={gameAssets ?? null}
         mode="hover"
         position={previewPosition ?? undefined}
@@ -740,9 +761,12 @@ const Board = forwardRef<BoardHandle, BoardProps>(function Board(
       />
 
       {/* Full-screen card preview - Mobile Double-Tap */}
-      {isModalVisible && modalPreviewCard && (
+      {isModalVisible && modalPreviewCard && gameAssets && (
         <FullScreenCardPreview
-          card={modalPreviewCard}
+          card={modalPreviewCard.card}
+          cardCode={modalPreviewCard.cardCode}
+          faceUp={modalPreviewCard.faceUp}
+          gameAssets={gameAssets}
           onClose={() => {
             setIsModalVisible(false);
             setModalPreviewCard(null);

--- a/app/src/components/CardPreview.test.tsx
+++ b/app/src/components/CardPreview.test.tsx
@@ -762,4 +762,207 @@ describe('CardPreview', () => {
       expect(screen.getByText('Loading...')).toBeInTheDocument();
     });
   });
+
+  // ==========================================================================
+  // Face-down back-image preview: show resolved back when non-default,
+  // suppress when default cardType.back. Mirrors hover/modal behavior.
+  // ==========================================================================
+  describe('Face-down back-image resolution', () => {
+    const playerCardType: CardType = {
+      back: 'https://example.com/generic-back.png',
+      size: 'standard',
+    };
+
+    it('shows partner face URL when face-down card has back_code pointing at an existing card', () => {
+      const card: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097a.jpg',
+        back_code: '01097b',
+      };
+      const partner: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097b.jpg',
+      };
+      const gameAssets = createGameAssets(
+        {
+          main_scheme: {
+            back: 'https://example.com/generic-scheme-back.png',
+            size: 'standard',
+          },
+        },
+        { '01097a': card, '01097b': partner },
+      );
+
+      render(
+        <CardPreview
+          card={card}
+          cardCode="01097a"
+          faceUp={false}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const img = screen.getByAltText<HTMLImageElement>('Card preview');
+      expect(img.src).toBe('https://example.com/01097b.jpg');
+    });
+
+    it('shows explicit card.back URL when face-down with no back_code', () => {
+      const card: Card = {
+        type: 'player',
+        face: 'https://example.com/face.jpg',
+        back: 'https://example.com/explicit-back.jpg',
+      };
+      const gameAssets = createGameAssets(
+        { player: playerCardType },
+        { card1: card },
+      );
+
+      render(
+        <CardPreview
+          card={card}
+          cardCode="card1"
+          faceUp={false}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const img = screen.getByAltText<HTMLImageElement>('Card preview');
+      expect(img.src).toBe('https://example.com/explicit-back.jpg');
+    });
+
+    it('renders nothing when face-down card resolves to the generic cardType.back', () => {
+      const card: Card = {
+        type: 'player',
+        face: 'https://example.com/face.jpg',
+      };
+      const gameAssets = createGameAssets(
+        { player: playerCardType },
+        { card1: card },
+      );
+
+      const { container } = render(
+        <CardPreview
+          card={card}
+          cardCode="card1"
+          faceUp={false}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when face-down card has back_code pointing at a missing card', () => {
+      const card: Card = {
+        type: 'player',
+        face: 'https://example.com/face.jpg',
+        back_code: 'NONEXISTENT',
+      };
+      const gameAssets = createGameAssets(
+        { player: playerCardType },
+        { card1: card },
+      );
+
+      // Suppress the expected resolver warn so it doesn't pollute output
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+      const { container } = render(
+        <CardPreview
+          card={card}
+          cardCode="card1"
+          faceUp={false}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('shows the face when faceUp is true, regardless of back_code', () => {
+      const card: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097a.jpg',
+        back_code: '01097b',
+      };
+      const partner: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097b.jpg',
+      };
+      const gameAssets = createGameAssets(
+        {
+          main_scheme: {
+            back: 'https://example.com/generic-scheme-back.png',
+            size: 'standard',
+          },
+        },
+        { '01097a': card, '01097b': partner },
+      );
+
+      render(
+        <CardPreview
+          card={card}
+          cardCode="01097a"
+          faceUp={true}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const img = screen.getByAltText<HTMLImageElement>('Card preview');
+      expect(img.src).toBe('https://example.com/01097a.jpg');
+    });
+
+    it('falls back to legacy face-only behavior when cardCode is omitted', () => {
+      // Legacy callers that haven't migrated to the new shape should keep
+      // working: face is shown unconditionally.
+      const card: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097a.jpg',
+        back_code: '01097b',
+      };
+      const partner: Card = {
+        type: 'main_scheme',
+        face: 'https://example.com/01097b.jpg',
+      };
+      const gameAssets = createGameAssets(
+        {
+          main_scheme: {
+            back: 'https://example.com/generic-scheme-back.png',
+            size: 'standard',
+          },
+        },
+        { '01097a': card, '01097b': partner },
+      );
+
+      render(
+        <CardPreview
+          card={card}
+          gameAssets={gameAssets}
+          mode="hover"
+          position={{ x: 100, y: 100 }}
+          onClose={mockOnClose}
+        />,
+      );
+
+      const img = screen.getByAltText<HTMLImageElement>('Card preview');
+      expect(img.src).toBe('https://example.com/01097a.jpg');
+    });
+  });
 });

--- a/app/src/components/CardPreview.tsx
+++ b/app/src/components/CardPreview.tsx
@@ -8,6 +8,7 @@ import {
 import useImage from 'use-image';
 import type { Card, GameAssets } from '@cardtable2/shared';
 import { getCardOrientation } from '../content/utils';
+import { resolveCardBackUrl } from '../content/loader';
 import {
   getPreviewDimensions,
   getLandscapeDimensions,
@@ -18,7 +19,21 @@ import {
 export interface CardPreviewProps {
   /** Card data to preview */
   card: Card | null;
-  /** Game assets for orientation lookup */
+  /**
+   * Card code (key in gameAssets.cards). Only required to resolve back-image
+   * URLs via back_code (i.e., when `faceUp` is false). When omitted, the
+   * component shows the face — preserves the legacy "always show face"
+   * behavior for callers that haven't migrated.
+   */
+  cardCode?: string | null;
+  /**
+   * Whether the card on the table is face-up. Defaults to true (face-up =
+   * legacy behavior). When false, the back is resolved via card.back / the
+   * back_code partner / cardType.back; the preview is suppressed entirely if
+   * the resolved back is the generic cardType.back.
+   */
+  faceUp?: boolean;
+  /** Game assets for orientation lookup and back-image resolution */
   gameAssets: GameAssets | null;
   /** Display mode: hover (positioned) or modal (centered) */
   mode: 'hover' | 'modal';
@@ -35,6 +50,38 @@ export interface CardPreviewProps {
 }
 
 /**
+ * Decide whether to render any preview at all for a face-down card.
+ *
+ * A card whose back is just the generic `cardType.back` (the same image every
+ * card of that type shows when face-down) is uninteresting to preview — the
+ * user already sees that exact image on the table. We only render a preview
+ * when the back is non-default: an explicit `card.back` URL, or a resolved
+ * `back_code` partner. The resolver compared against `cardType.back` is the
+ * authoritative source-of-truth for "is this back interesting?"
+ *
+ * Returns the URL to render, or `null` if no preview should be shown.
+ */
+function resolvePreviewImageUrl(
+  card: Card,
+  cardCode: string,
+  faceUp: boolean,
+  gameAssets: GameAssets,
+): string | null {
+  if (faceUp) {
+    return card.face;
+  }
+  const cardType = gameAssets.cardTypes[card.type];
+  if (!cardType) {
+    return null;
+  }
+  const backUrl = resolveCardBackUrl(cardCode, card, cardType, gameAssets);
+  if (!backUrl || backUrl === cardType.back) {
+    return null;
+  }
+  return backUrl;
+}
+
+/**
  * CardPreview - Display card image in larger size
  *
  * Supports two modes:
@@ -45,6 +92,8 @@ export interface CardPreviewProps {
  */
 export function CardPreview({
   card,
+  cardCode = null,
+  faceUp = true,
   gameAssets,
   mode,
   position = { x: 0, y: 0 },
@@ -53,13 +102,23 @@ export function CardPreview({
   rotationEnabled = DEFAULT_ROTATION_ENABLED,
   onClose,
 }: CardPreviewProps) {
-  const isOpen = card !== null && gameAssets !== null;
+  // Determine the URL to render. For face-up: card.face. For face-down: the
+  // resolved back URL via card.back / back_code, but only if it's *non-default*
+  // (the generic cardType.back returns null — no preview, since the user already
+  // sees that exact image on the table). When cardCode is omitted, fall back
+  // to the legacy "show face" behavior — back-resolution requires the code.
+  const imageUrl =
+    card === null || gameAssets === null
+      ? null
+      : faceUp || cardCode === null
+        ? card.face
+        : resolvePreviewImageUrl(card, cardCode, faceUp, gameAssets);
+  const isOpen = imageUrl !== null;
 
-  // Image URL (always show face for preview)
-  const imageUrl = card?.face ?? '';
-
-  // Load image with hook (must be called unconditionally)
-  const [image, status] = useImage(imageUrl);
+  // Load image with hook (must be called unconditionally — useImage takes a
+  // string; empty string is the loader's "no-op" sentinel, used when there's
+  // nothing to preview).
+  const [image, status] = useImage(imageUrl ?? '');
 
   // Log image loading failures for debugging
   useEffect(() => {
@@ -121,8 +180,15 @@ export function CardPreview({
     return { dimensions, needsRotation, rotationTransform };
   }, [card, gameAssets, rotationEnabled, image, size, customDimensions]);
 
+  // Nothing to render: missing inputs, or face-down card whose back resolves
+  // to the generic cardType.back (no point previewing what's already on the
+  // table).
+  if (!card || !gameAssets || imageUrl === null) {
+    return null;
+  }
+
   // Early return for hover mode
-  if (card && gameAssets && mode === 'hover') {
+  if (mode === 'hover') {
     const { dimensions, rotationTransform } = getCardDisplayProps();
 
     return (
@@ -169,10 +235,6 @@ export function CardPreview({
         </div>
       </div>
     );
-  }
-
-  if (!card || !gameAssets) {
-    return null;
   }
 
   // Calculate rotation and dimensions for modal mode

--- a/app/src/components/FullScreenCardPreview.tsx
+++ b/app/src/components/FullScreenCardPreview.tsx
@@ -1,16 +1,51 @@
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import type { Card } from '@cardtable2/shared';
+import type { Card, GameAssets } from '@cardtable2/shared';
+import { resolveCardBackUrl } from '../content/loader';
 
 const IGNORE_GESTURES_MS = 300;
 
 interface FullScreenCardPreviewProps {
   card: Card;
+  cardCode: string;
+  faceUp: boolean;
+  gameAssets: GameAssets;
   onClose: () => void;
+}
+
+/**
+ * Decide which side of the card to show in the modal preview.
+ *
+ * Mirrors `CardPreview`'s rule: face-up shows the face; face-down with a
+ * non-default back (`card.back` or a `back_code` partner) shows that back;
+ * face-down with the generic `cardType.back` shows nothing — the user already
+ * saw that exact image on the table when they double-tapped.
+ */
+function resolvePreviewImageUrl(
+  card: Card,
+  cardCode: string,
+  faceUp: boolean,
+  gameAssets: GameAssets,
+): string | null {
+  if (faceUp) {
+    return card.face;
+  }
+  const cardType = gameAssets.cardTypes[card.type];
+  if (!cardType) {
+    return null;
+  }
+  const backUrl = resolveCardBackUrl(cardCode, card, cardType, gameAssets);
+  if (!backUrl || backUrl === cardType.back) {
+    return null;
+  }
+  return backUrl;
 }
 
 export function FullScreenCardPreview({
   card,
+  cardCode,
+  faceUp,
+  gameAssets,
   onClose,
 }: FullScreenCardPreviewProps) {
   const openTimeRef = useRef(Date.now());
@@ -22,6 +57,11 @@ export function FullScreenCardPreview({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
+
+  const imageUrl = resolvePreviewImageUrl(card, cardCode, faceUp, gameAssets);
+  if (imageUrl === null) {
+    return null;
+  }
 
   return createPortal(
     <div
@@ -48,7 +88,7 @@ export function FullScreenCardPreview({
       }}
     >
       <img
-        src={card.face}
+        src={imageUrl}
         alt="Card preview"
         style={{
           maxWidth: 'clamp(280px, 60vw, 450px)',

--- a/app/src/components/HandPanel.tsx
+++ b/app/src/components/HandPanel.tsx
@@ -104,8 +104,10 @@ export const HandPanel = forwardRef<HTMLDivElement, HandPanelProps>(
     );
     const [canScrollLeft, setCanScrollLeft] = useState(false);
     const [canScrollRight, setCanScrollRight] = useState(false);
-    const [doubleTapPreviewCard, setDoubleTapPreviewCard] =
-      useState<Card | null>(null);
+    const [doubleTapPreviewCard, setDoubleTapPreviewCard] = useState<{
+      card: Card;
+      cardCode: string;
+    } | null>(null);
     const [insertionIndex, setInsertionIndex] = useState<number | null>(null);
 
     const cardsContainerRef = useRef<HTMLDivElement>(null);
@@ -316,8 +318,8 @@ export const HandPanel = forwardRef<HTMLDivElement, HandPanelProps>(
           const cardId = cards[index];
           const card =
             cardId && gameAssets ? (gameAssets.cards[cardId] ?? null) : null;
-          if (card) {
-            setDoubleTapPreviewCard(card);
+          if (card && cardId) {
+            setDoubleTapPreviewCard({ card, cardCode: cardId });
           }
           lastTapTimeRef.current.delete(index);
         } else {
@@ -644,9 +646,11 @@ export const HandPanel = forwardRef<HTMLDivElement, HandPanelProps>(
       };
     })();
 
+    const hoveredCardCode =
+      hoveredIndex !== null ? (cards[hoveredIndex] ?? null) : null;
     const hoveredCard =
-      hoveredIndex !== null && gameAssets
-        ? (gameAssets.cards[cards[hoveredIndex]] ?? null)
+      hoveredCardCode && gameAssets
+        ? (gameAssets.cards[hoveredCardCode] ?? null)
         : null;
 
     // Phantom drag ghost image URL
@@ -846,6 +850,8 @@ export const HandPanel = forwardRef<HTMLDivElement, HandPanelProps>(
             <div style={{ pointerEvents: 'none' }}>
               <CardPreview
                 card={hoveredCard}
+                cardCode={hoveredCardCode}
+                faceUp={true}
                 gameAssets={gameAssets}
                 mode="hover"
                 position={previewPosition}
@@ -890,10 +896,14 @@ export const HandPanel = forwardRef<HTMLDivElement, HandPanelProps>(
             document.body,
           )}
 
-        {/* Full-screen card preview — touch double-tap */}
-        {doubleTapPreviewCard && (
+        {/* Full-screen card preview — touch double-tap. Hand cards are
+            always face-up, so the preview always shows the face. */}
+        {doubleTapPreviewCard && gameAssets && (
           <FullScreenCardPreview
-            card={doubleTapPreviewCard}
+            card={doubleTapPreviewCard.card}
+            cardCode={doubleTapPreviewCard.cardCode}
+            faceUp={true}
+            gameAssets={gameAssets}
             onClose={() => setDoubleTapPreviewCard(null)}
           />
         )}

--- a/app/src/content/loader.test.ts
+++ b/app/src/content/loader.test.ts
@@ -551,6 +551,232 @@ describe('resolveCard', () => {
     const resolved = resolveCard('custom', contentWithCustomSize);
     expect(resolved.size).toEqual([300, 400]);
   });
+
+  // ==========================================================================
+  // back_code resolution (two-sided cards)
+  // ==========================================================================
+
+  describe('back_code resolution', () => {
+    it('should use partner card face as back when back_code points at an existing card', () => {
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          mainScheme: { back: 'main_scheme_back.jpg', size: 'standard' },
+        },
+        cards: {
+          '01097a': {
+            type: 'mainScheme',
+            face: '01097a.jpg',
+            back_code: '01097',
+          },
+          '01097': {
+            type: 'mainScheme',
+            face: '01097.jpg',
+            back_code: '01097a',
+          },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolvedA = resolveCard('01097a', merged);
+      expect(resolvedA.back).toBe('https://example.com/mc/01097.jpg');
+
+      const resolvedB = resolveCard('01097', merged);
+      expect(resolvedB.back).toBe('https://example.com/mc/01097a.jpg');
+    });
+
+    it('should fall through to cardType.back and warn when back_code points at a missing card', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          encounter: { back: 'encounter_back.jpg', size: 'standard' },
+        },
+        cards: {
+          orphan: {
+            type: 'encounter',
+            face: 'orphan.jpg',
+            back_code: 'does_not_exist',
+          },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolved = resolveCard('orphan', merged);
+      expect(resolved.back).toBe('https://example.com/mc/encounter_back.jpg');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const warnArgs = warnSpy.mock.calls[0];
+      expect(warnArgs[0]).toContain('back_code references unknown card');
+      expect(warnArgs[1]).toMatchObject({
+        cardCode: 'orphan',
+        backCode: 'does_not_exist',
+      });
+
+      warnSpy.mockRestore();
+    });
+
+    it('should prefer card.back over back_code (per-card explicit override wins)', () => {
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          mainScheme: { back: 'main_scheme_back.jpg', size: 'standard' },
+        },
+        cards: {
+          '01097a': {
+            type: 'mainScheme',
+            face: '01097a.jpg',
+            back: 'explicit_back.jpg',
+            back_code: '01097',
+          },
+          '01097': {
+            type: 'mainScheme',
+            face: '01097.jpg',
+          },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolved = resolveCard('01097a', merged);
+      expect(resolved.back).toBe('https://example.com/mc/explicit_back.jpg');
+    });
+
+    it('should fall through to cardType.back when neither back nor back_code is provided (current behavior preserved)', () => {
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          hero: { back: 'hero_back.jpg', size: 'standard' },
+        },
+        cards: {
+          plain: { type: 'hero', face: 'plain.jpg' },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolved = resolveCard('plain', merged);
+      expect(resolved.back).toBe('https://example.com/mc/hero_back.jpg');
+    });
+
+    it('should resolve back_code across packs (partner in a different pack with different baseUrl)', () => {
+      const corePack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'core',
+        name: 'Core',
+        version: '1.0.0',
+        baseUrl: 'https://cdn-a.example.com/core/',
+        cardTypes: {
+          hero: { back: 'hero_back.jpg', size: 'standard' },
+        },
+        cards: {
+          spider_man: {
+            type: 'hero',
+            face: 'spider_man.jpg',
+            back_code: 'peter_parker',
+          },
+        },
+      };
+      const expansionPack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'expansion',
+        name: 'Expansion',
+        version: '1.0.0',
+        baseUrl: 'https://cdn-b.example.com/expansion/',
+        cards: {
+          peter_parker: {
+            type: 'hero',
+            face: 'peter_parker.jpg',
+          },
+        },
+      };
+      const merged = mergeAssetPacks([corePack, expansionPack]);
+
+      const resolved = resolveCard('spider_man', merged);
+      // Partner's face was resolved against expansionPack's baseUrl, not corePack's.
+      expect(resolved.back).toBe(
+        'https://cdn-b.example.com/expansion/peter_parker.jpg',
+      );
+    });
+
+    it('should support asymmetric pairs: only one side declares back_code', () => {
+      // Hero declares back_code pointing at alter-ego; alter-ego does NOT
+      // declare back_code. Hero side should still flip correctly. Alter-ego
+      // side falls through to cardType.back.
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          hero: { back: 'generic_hero_back.jpg', size: 'standard' },
+        },
+        cards: {
+          spider_man: {
+            type: 'hero',
+            face: 'spider_man.jpg',
+            back_code: 'peter_parker',
+          },
+          peter_parker: {
+            type: 'hero',
+            face: 'peter_parker.jpg',
+            // No back_code declared — asymmetric.
+          },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolvedHero = resolveCard('spider_man', merged);
+      expect(resolvedHero.back).toBe('https://example.com/mc/peter_parker.jpg');
+
+      const resolvedAlterEgo = resolveCard('peter_parker', merged);
+      expect(resolvedAlterEgo.back).toBe(
+        'https://example.com/mc/generic_hero_back.jpg',
+      );
+    });
+
+    it('should support self-referencing back_code (single-image two-sided card)', () => {
+      // A card pointing at itself via back_code should render its own face on
+      // both sides. Edge case but valid — no need to special-case it.
+      const pack: AssetPack = {
+        schema: 'ct-assets@1',
+        id: 'mc',
+        name: 'MC',
+        version: '1.0.0',
+        baseUrl: 'https://example.com/mc/',
+        cardTypes: {
+          treachery: { back: 'treachery_back.jpg', size: 'standard' },
+        },
+        cards: {
+          self_ref: {
+            type: 'treachery',
+            face: 'self_ref.jpg',
+            back_code: 'self_ref',
+          },
+        },
+      };
+      const merged = mergeAssetPacks([pack]);
+
+      const resolved = resolveCard('self_ref', merged);
+      expect(resolved.back).toBe('https://example.com/mc/self_ref.jpg');
+    });
+  });
 });
 
 // ============================================================================

--- a/app/src/content/loader.ts
+++ b/app/src/content/loader.ts
@@ -4,6 +4,8 @@ import type {
   GameAssets,
   ResolvedCard,
   CardSize,
+  Card,
+  CardType,
 } from '@cardtable2/shared';
 import { getBackendUrl } from '@/utils/backend';
 import {
@@ -423,6 +425,53 @@ export function resolveAssetUrl(url: string, baseUrl?: string): string {
 // ============================================================================
 
 /**
+ * Resolve the back-image URL for a card, applying the full resolution chain.
+ *
+ * Precedence (highest first):
+ *   1. `card.back`                — explicit per-card back image override
+ *   2. partner card's `face`      — when `card.back_code` points to another
+ *                                   card, render that partner's face when this
+ *                                   card is face-down (two-sided cards: hero/
+ *                                   alter-ego pairs, multi-stage main schemes,
+ *                                   multi-back treacheries, etc.)
+ *   3. `cardType.back`            — generic back for the card's cardType
+ *
+ * Returns `undefined` if no back image can be resolved (caller decides whether
+ * that's an error). If `back_code` points at an unknown card code, logs a
+ * warning and falls through to `cardType.back` rather than throwing — soft
+ * failure, so a typo in one card's metadata doesn't break the whole table.
+ *
+ * URLs returned from this helper are assumed to already be absolute: cards
+ * passed in via `gameAssets.cards` and `cardType.back` have been processed by
+ * `mergeAssetPacks`, which resolves all asset URLs against each pack's
+ * `baseUrl` at load time. Cross-pack `back_code` therefore works correctly:
+ * the partner's `face` was resolved against the partner's pack, not the
+ * current card's.
+ */
+export function resolveCardBackUrl(
+  cardCode: string,
+  card: Card,
+  cardType: CardType,
+  content: GameAssets,
+): string | undefined {
+  if (card.back) {
+    return card.back;
+  }
+  if (card.back_code) {
+    const partner = content.cards[card.back_code];
+    if (partner) {
+      return partner.face;
+    }
+    console.warn('[Loader] back_code references unknown card; falling back', {
+      cardCode,
+      backCode: card.back_code,
+    });
+    return cardType.back;
+  }
+  return cardType.back;
+}
+
+/**
  * Resolve a card by applying type inheritance and URL resolution
  */
 export function resolveCard(
@@ -457,14 +506,15 @@ export function resolveCard(
   // Resolve size (card override > type default > standard)
   const size: CardSize = card.size ?? cardType.size ?? 'standard';
 
-  // Resolve back image (card override > type default)
-  const backUrl = card.back ?? cardType.back;
+  // Resolve back image via shared chain (card.back > back_code partner > cardType.back).
+  const backUrl = resolveCardBackUrl(cardCode, card, cardType, content);
   if (!backUrl) {
     console.error('[Loader] No back image defined for card', {
       errorId: CARD_IMAGE_NO_BACK,
       cardCode,
       cardType: card.type,
       hasCardBack: !!card.back,
+      hasBackCode: !!card.back_code,
       hasTypeBack: !!cardType.back,
     });
     throw new Error(
@@ -476,6 +526,9 @@ export function resolveCard(
     code: cardCode,
     type: card.type,
     face: resolveAssetUrl(card.face, baseUrl),
+    // resolveAssetUrl is idempotent for absolute URLs; the back URL is already
+    // resolved (mergeAssetPacks resolves card.back, cardType.back, and partner
+    // card faces at load time), so this call is a no-op for the common path.
     back: resolveAssetUrl(backUrl, baseUrl),
     size,
   };

--- a/app/src/renderer/objects/stack/behaviors.test.ts
+++ b/app/src/renderer/objects/stack/behaviors.test.ts
@@ -1357,4 +1357,165 @@ describe('Stack Behaviors - Visual Rendering', () => {
       });
     });
   });
+
+  // =========================================================================
+  // ct-vxu regression: don't re-attempt load() once a URL has failed
+  // =========================================================================
+  // Bug: when a card image 404s, the renderer's catch fires onTextureLoaded,
+  // which redrawVisual triggers a re-render, which hits the same load() path,
+  // which (past TextureLoader's retry limit) throws synchronously, which
+  // re-fires the catch, which fires onTextureLoaded again — infinite loop,
+  // browser locks. Fix: skip the load() call when textureLoader.hasFailed(url)
+  // is already true. These tests pin the guard so it can't regress silently.
+  describe('ct-vxu: failed-URL guard prevents render-load loop', () => {
+    function makeAssets(): RenderContext['gameAssets'] {
+      return {
+        packs: [],
+        cards: {
+          card1: {
+            type: 'player',
+            face: '/api/card-image/pack1/card1-face.jpg',
+          },
+        },
+        cardTypes: {
+          player: { back: '/api/card-image/pack1/player-back.jpg' },
+        },
+        cardSets: {},
+        tokens: {},
+        counters: {},
+        mats: {},
+        tokenTypes: {},
+        statusTypes: {},
+        modifierStats: {},
+        iconTypes: {},
+      };
+    }
+
+    it('does not call load() when textureLoader.hasFailed returns true (main card path)', () => {
+      const loadMock = vi.fn(() =>
+        Promise.reject(new Error('should not be called')),
+      );
+      const textureLoader: Partial<RenderContext['textureLoader']> = {
+        load: loadMock,
+        get: vi.fn(() => undefined),
+        has: vi.fn(() => false),
+        shouldShowFallback: vi.fn(() => true),
+        isSlowLoading: vi.fn(() => false),
+        hasFailed: vi.fn(() => true),
+      };
+      const ctx = {
+        ...mockContext,
+        gameAssets: makeAssets(),
+        textureLoader: textureLoader as TextureLoader,
+        onTextureLoaded: vi.fn(),
+      } as RenderContext;
+
+      const stack = createTestStack({ _cards: ['card1'], _faceUp: true });
+
+      // Render many times — like the redrawVisual cascade would.
+      for (let i = 0; i < 50; i++) {
+        StackBehaviors.render(stack, ctx);
+      }
+
+      expect(loadMock).not.toHaveBeenCalled();
+      expect(textureLoader.hasFailed).toHaveBeenCalled();
+    });
+
+    it('calls load() exactly once across renders, when hasFailed flips to true after first failure', () => {
+      const loadMock = vi.fn(() => Promise.reject(new Error('boom')));
+      let hasFailedReturn = false;
+      const textureLoader: Partial<RenderContext['textureLoader']> = {
+        load: loadMock,
+        get: vi.fn(() => undefined),
+        has: vi.fn(() => false),
+        shouldShowFallback: vi.fn(() => false),
+        isSlowLoading: vi.fn(() => false),
+        hasFailed: vi.fn(() => hasFailedReturn),
+      };
+      const ctx = {
+        ...mockContext,
+        gameAssets: makeAssets(),
+        textureLoader: textureLoader as TextureLoader,
+        onTextureLoaded: vi.fn(),
+      } as RenderContext;
+
+      const stack = createTestStack({ _cards: ['card1'], _faceUp: true });
+
+      // First render kicks off load().
+      StackBehaviors.render(stack, ctx);
+      expect(loadMock).toHaveBeenCalledTimes(1);
+
+      // Simulate the load having failed: failedUrls now records this URL,
+      // so hasFailed() flips to true. Subsequent renders must NOT call load.
+      hasFailedReturn = true;
+      for (let i = 0; i < 50; i++) {
+        StackBehaviors.render(stack, ctx);
+      }
+
+      expect(loadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call load() for status/token/icon images when hasFailed is true', () => {
+      const loadMock = vi.fn(() =>
+        Promise.reject(new Error('should not be called')),
+      );
+      const textureLoader: Partial<RenderContext['textureLoader']> = {
+        load: loadMock,
+        get: vi.fn(() => undefined),
+        has: vi.fn(() => false),
+        shouldShowFallback: vi.fn(() => false),
+        isSlowLoading: vi.fn(() => false),
+        hasFailed: vi.fn(() => true),
+      };
+      const ctx = {
+        ...mockContext,
+        gameAssets: {
+          packs: [],
+          cards: {
+            card1: {
+              type: 'player',
+              face: '/api/card-image/pack1/card1-face.jpg',
+            },
+          },
+          cardTypes: {
+            player: { back: '/api/card-image/pack1/player-back.jpg' },
+          },
+          cardSets: {},
+          tokens: {},
+          counters: {},
+          mats: {},
+          tokenTypes: {
+            damage: { name: 'Damage', image: '/tokens/damage.png' },
+          },
+          statusTypes: {
+            stunned: { name: 'Stunned', image: '/status/stunned.png' },
+          },
+          modifierStats: {},
+          iconTypes: {
+            attack: { name: 'Attack', image: '/icons/attack.png' },
+          },
+        },
+        textureLoader: textureLoader as TextureLoader,
+        onTextureLoaded: vi.fn(),
+      } as RenderContext;
+
+      const stack = createTestStack({
+        _cards: ['card1'],
+        _faceUp: true,
+        _meta: {
+          card1: {
+            tokens: { damage: 1 },
+            statuses: ['stunned'],
+            icons: ['attack'],
+          },
+        },
+      });
+
+      for (let i = 0; i < 20; i++) {
+        StackBehaviors.render(stack, ctx);
+      }
+
+      expect(loadMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/src/renderer/objects/stack/behaviors.ts
+++ b/app/src/renderer/objects/stack/behaviors.ts
@@ -273,10 +273,21 @@ function renderMainCard(
       container.addChild(text);
     }
 
-    // Start async texture load and trigger re-render when done
-    // Note: TextureLoader tracks slow loads internally via isSlowLoading()
-    // We rely on periodic re-renders (e.g., from user interaction) to check shouldShowFallback()
-    if (imageUrl && ctx.textureLoader && ctx.onTextureLoaded) {
+    // Start async texture load and trigger re-render when done.
+    // Critical: bail out if this URL has already failed. Without this guard,
+    // a permanently-broken URL produces an infinite render loop (ct-vxu):
+    //   load() rejects -> .catch fires onTextureLoaded -> redrawVisual ->
+    //   re-render hits this same path -> load() rejects synchronously past
+    //   the retry limit -> .catch -> onTextureLoaded -> redrawVisual -> ...
+    // The first failure already incremented failedUrls; subsequent renders
+    // see hasFailed=true and stop. The placeholder + fallback text from the
+    // first re-render is what the user sees; no further updates needed.
+    if (
+      imageUrl &&
+      ctx.textureLoader &&
+      ctx.onTextureLoaded &&
+      !ctx.textureLoader.hasFailed(imageUrl)
+    ) {
       ctx.textureLoader
         .load(imageUrl)
         .then(() => {
@@ -621,8 +632,13 @@ function renderStatus(
 
       currentY += cachedTexture.height * scale + 2;
     } else {
-      // Start async load
-      if (ctx.textureLoader && ctx.onTextureLoaded) {
+      // Start async load. Skip if already known broken (ct-vxu) — every
+      // render would otherwise re-attempt the same failing URL.
+      if (
+        ctx.textureLoader &&
+        ctx.onTextureLoaded &&
+        !ctx.textureLoader.hasFailed(statusDef.image)
+      ) {
         ctx.textureLoader
           .load(statusDef.image)
           .then(() => {
@@ -792,8 +808,12 @@ function renderTokens(
 
       currentY += sprite.height + ATTACHMENT_VERTICAL_SPACING;
     } else {
-      // Start async load
-      if (ctx.textureLoader && ctx.onTextureLoaded) {
+      // Start async load. Skip if already known broken (ct-vxu).
+      if (
+        ctx.textureLoader &&
+        ctx.onTextureLoaded &&
+        !ctx.textureLoader.hasFailed(tokenDef.image)
+      ) {
         ctx.textureLoader
           .load(tokenDef.image)
           .then(() => {
@@ -861,8 +881,12 @@ function renderIcons(
 
       currentY += sprite.height + ATTACHMENT_VERTICAL_SPACING;
     } else {
-      // Start async load
-      if (ctx.textureLoader && ctx.onTextureLoaded) {
+      // Start async load. Skip if already known broken (ct-vxu).
+      if (
+        ctx.textureLoader &&
+        ctx.onTextureLoaded &&
+        !ctx.textureLoader.hasFailed(iconDef.image)
+      ) {
         ctx.textureLoader
           .load(iconDef.image)
           .then(() => {

--- a/app/src/renderer/objects/stack/behaviors.ts
+++ b/app/src/renderer/objects/stack/behaviors.ts
@@ -41,6 +41,7 @@ import {
 import { getStackColor, getCardCount } from './utils';
 import { renderStackPopIcon } from '../../graphics/stackPop';
 import { shouldRotateCard } from '../../../content/cardRotation';
+import { resolveCardBackUrl } from '../../../content/loader';
 import {
   TEXTURE_LOAD_FAILED,
   ATTACHMENT_IMAGE_LOAD_FAILED,
@@ -113,15 +114,16 @@ function getCardImageUrl(
     );
     return { success: false, reason: 'no-face', cardId: topCardId };
   } else {
-    // Face down - show card back (from card override or card type default)
-    if (card.back) {
-      return { success: true, url: card.back };
-    }
-
-    // Fall back to card type's back image
+    // Face down - show card back. Uses the shared resolver so two-sided
+    // cards (back_code) flip to the partner's face, not the generic
+    // cardType back. Resolution chain: card.back > partner.face > cardType.back.
     const cardType = ctx.gameAssets.cardTypes[card.type];
-    if (cardType?.back) {
-      return { success: true, url: cardType.back };
+    const backUrl = cardType
+      ? resolveCardBackUrl(topCardId, card, cardType, ctx.gameAssets)
+      : (card.back ?? undefined);
+
+    if (backUrl) {
+      return { success: true, url: backUrl };
     }
 
     console.error(
@@ -131,6 +133,7 @@ function getCardImageUrl(
         cardId: topCardId,
         cardType: card.type,
         hasCardBack: !!card.back,
+        hasBackCode: !!card.back_code,
         hasTypeBack: !!cardType?.back,
         stackObjectId: ctx.objectId,
       },

--- a/shared/schemas/ct-assets-v1.schema.json
+++ b/shared/schemas/ct-assets-v1.schema.json
@@ -81,6 +81,10 @@
             "type": "string",
             "description": "Optional card back image URL (overrides type default)"
           },
+          "back_code": {
+            "type": "string",
+            "description": "Optional partner card code; when face-down, render the partner's `face` (used for two-sided cards like hero/alter-ego pairs and multi-stage main schemes). Resolution order: card.back > partner.face > cardType.back."
+          },
           "size": {
             "oneOf": [
               {

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -55,6 +55,7 @@ export interface Card {
   type: string; // References a cardType key
   face: string; // Card face image URL
   back?: string; // Optional override of type's back image
+  back_code?: string; // Optional partner card code; when face-down, render the partner's `face` (used for two-sided cards like hero/alter-ego pairs and multi-stage main schemes). Resolution order: card.back > partner.face > cardType.back.
   size?: CardSize; // Optional override of type's size
   orientation?: CardOrientation; // Optional override of type's orientation (follows inheritance: card → cardType → 'portrait')
   setCode?: string; // Optional set/group identifier (e.g. "spider_man_nemesis") — used by deck import parsers


### PR DESCRIPTION
## Summary

Two-tier change in this PR — both renderer-touching, both verified via Playwright MCP against a live MC plugin:

### 1. ct-r1p: `back_code` resolution for two-sided card backs

Three-tier back-image resolution chain (`card.back` > partner's `face` via `back_code` > `cardType.back`), wired into both the load-time path (`resolveCard`) and the render hot path (`behaviors.ts:getCardImageUrl`) via a shared `resolveCardBackUrl` helper. Backwards-compatible: cards without `back_code` keep working identically. MC plugin payoff at merge: Rhino main scheme, hero ↔ alter-ego pairs, Ultron treacheries all start flipping correctly with no plugin update needed.

### 2. ct-vxu: P0 fix for browser lockup on image-load failure

While QA-ing #1 against the MC plugin, the user hit a recurring critical bug: a face-down card whose back URL 404s sent the renderer into an infinite render-load-fail loop, freezing the tab. Root cause: `behaviors.ts` `.catch()` fired `onTextureLoaded`, which triggered `redrawVisual`, which re-rendered, which called `load()` again, which (past the retry limit) threw synchronously, which… loop. Fix: in all four image-load sites (main card, status, token, icon), skip `textureLoader.load()` when `textureLoader.hasFailed(url)` is already true. The first failure flips the flag; subsequent renders show the existing placeholder + fallback text without re-attempting. 3 regression tests added.

## Test plan

- [x] `pnpm run typecheck` (monorepo: shared + server + app) — clean
- [x] `pnpm --filter app run test --run` — 1087 tests pass (50 in `loader.test.ts` for back_code; 63 in `behaviors.test.ts` including 3 new ct-vxu regression tests)
- [x] `pnpm --filter app run lint` — clean
- [x] `pnpm --filter shared run lint` — clean
- [x] `jq empty shared/schemas/ct-assets-v1.schema.json` — valid
- [x] **Playwright MCP**: ct-r1p — seeded face-down `01097a` against live MC `gameAssets`; renderer requested partner `01097.jpg` (correct back_code resolution), all 4 resolver cases verified end-to-end
- [x] **Playwright MCP**: ct-vxu — same scenario as a stress test (the partner URL 404s); exactly 2 console errors over 3 seconds, main thread responsive throughout (vs. runaway thousands the old code produced)

## Closes

- ct-r1p (back_code resolution)
- ct-vxu (browser lockup on image load failure)

## Related (open, not blocking this PR)

- ct-xtl (P3 investigation) — Rhino main scheme `01097a` has `back_code: '01097'` which resolves to a card whose face URL 404s (the user expected `01097B`). Likely plugin-data fix in `cardtable-plugin-marvelchampions`, not a runtime issue.