### PR TITLE
chore: post-loadables UX cleanups

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(bd:*)",
-      "Bash(jq -r *)",
+      "Bash(jq:*)",
+      "Bash(rg:*)",
       "Bash(pnpm typecheck)",
       "Bash(pnpm test)",
       "Bash(pnpm test:e2e)",

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "rbush": "^4.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-konami-code": "^2.3.0",
     "unique-names-generator": "^4.7.1",
     "use-image": "^1.1.4",
     "uuid": "^13.0.0",

--- a/app/src/__tests__/routes/index.test.tsx
+++ b/app/src/__tests__/routes/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import {
   createMemoryHistory,
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-router';
 import { routeTree } from '../../routeTree.gen';
 import type { PluginRegistry } from '../../content/pluginLoader';
+import { DEV_MODE_STORAGE_KEY } from '../../hooks/useDevMode';
 
 const mockPluginRegistry: PluginRegistry = {
   plugins: [
@@ -160,6 +161,84 @@ describe('Index Route (GameSelect)', () => {
 
     await waitFor(() => {
       expect(router.state.location.pathname).toMatch(/^\/table\//);
+    });
+  });
+
+  describe('local-directory button visibility (ct-824)', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockPluginRegistry),
+          } as Response),
+        ),
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      window.localStorage.clear();
+    });
+
+    const renderRoute = async () => {
+      const router = createTestRouter();
+      await act(async () => {
+        render(<RouterProvider router={router} />);
+        await router.load();
+      });
+      // Wait until the games list has rendered — the local-dir button
+      // lives in the same `<main>` and only appears once the registry
+      // resolves.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Select Fake Game' }),
+        ).toBeInTheDocument();
+      });
+    };
+
+    it('shows the local-directory button in Vite DEV mode by default', async () => {
+      vi.stubEnv('DEV', true);
+      await renderRoute();
+      expect(
+        screen.getByRole('button', { name: /Load from local directory/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides the local-directory button outside DEV when no dev-mode is persisted', async () => {
+      vi.stubEnv('DEV', false);
+      await renderRoute();
+      expect(
+        screen.queryByRole('button', { name: /Load from local directory/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the local-directory button outside DEV when dev-mode is persisted', async () => {
+      vi.stubEnv('DEV', false);
+      window.localStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+      await renderRoute();
+      expect(
+        screen.getByRole('button', { name: /Load from local directory/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the "dev" indicator only when revealed via persisted dev-mode (not in DEV)', async () => {
+      vi.stubEnv('DEV', false);
+      window.localStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+      await renderRoute();
+      expect(screen.getByLabelText('dev mode')).toBeInTheDocument();
+    });
+
+    it('does not show the "dev" indicator when in Vite DEV mode', async () => {
+      vi.stubEnv('DEV', true);
+      await renderRoute();
+      // Button is visible, indicator is not — the button itself signals "dev".
+      expect(
+        screen.getByRole('button', { name: /Load from local directory/i }),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText('dev mode')).not.toBeInTheDocument();
     });
   });
 });

--- a/app/src/components/load-picker/CardPreviewPopover.tsx
+++ b/app/src/components/load-picker/CardPreviewPopover.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import type { Card, GameAssets } from '@cardtable2/shared';
+import { CardPreview } from '../CardPreview';
+import {
+  getPreviewDimensions,
+  DEFAULT_PREVIEW_SIZE,
+} from '../../constants/previewSizes';
+
+/**
+ * Estimated preview width used for off-viewport flipping. We don't know
+ * the exact rendered width until `CardPreview` lays out (the image may
+ * rotate for landscape cards), but the medium-portrait preset is a safe
+ * upper-bound for the row-icon affordance. Slight over-estimate is
+ * harmless; under-estimate would clip the right edge.
+ */
+const PREVIEW_WIDTH_HINT = getPreviewDimensions(DEFAULT_PREVIEW_SIZE).width;
+
+/** Padding from the edge of the viewport when flipping. */
+const VIEWPORT_PADDING = 12;
+
+/** Horizontal gap between the anchor and the preview. */
+const ANCHOR_GAP = 12;
+
+interface CardPreviewPopoverProps {
+  /** Card to preview. */
+  card: Card;
+  /** Card code (for back-image resolution; we only ever show face here). */
+  cardCode: string;
+  /** Game assets — passed through to `CardPreview` for orientation lookup. */
+  gameAssets: GameAssets;
+  /** The element the popover is anchored to (the eye icon). */
+  anchorEl: HTMLElement;
+  /** Close handler — fired when the host wants to dismiss. */
+  onClose: () => void;
+}
+
+/**
+ * Desktop hover-mode preview for the load picker (ct-87o).
+ *
+ * Computes a viewport-relative `(x, y)` from the anchor element's bounding
+ * rect, then defers to `CardPreview` (`mode='hover'`) for the actual
+ * rendering — same component the table-side hover preview uses, so the
+ * picker preview matches the table preview's visuals (rotation,
+ * dimensions, gray-while-loading box).
+ *
+ * Position strategy: place to the right of the anchor when there's room;
+ * flip to the left otherwise. Vertically: align the preview's top with
+ * the anchor's middle, but clamp to keep the preview on-screen. We
+ * recompute on every scroll/resize while open so the popover stays
+ * pinned to the moving anchor (the modal's item list is scrollable).
+ */
+export function CardPreviewPopover({
+  card,
+  cardCode,
+  gameAssets,
+  anchorEl,
+  onClose,
+}: CardPreviewPopoverProps) {
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    function recompute() {
+      const rect = anchorEl.getBoundingClientRect();
+      const viewportW = window.innerWidth;
+      const viewportH = window.innerHeight;
+
+      // Default: place to the right of the anchor.
+      let x = rect.right + ANCHOR_GAP;
+      // Flip if it would overflow the right edge.
+      if (x + PREVIEW_WIDTH_HINT + VIEWPORT_PADDING > viewportW) {
+        x = rect.left - ANCHOR_GAP - PREVIEW_WIDTH_HINT;
+        // If flipping also overflows the left, clamp into the viewport.
+        if (x < VIEWPORT_PADDING) x = VIEWPORT_PADDING;
+      }
+
+      // Vertical: align top of preview slightly above the anchor's center.
+      // The exact preview height varies by card orientation; clamp at the
+      // bottom so it never runs off-screen (the top clamp is just the
+      // viewport edge).
+      let y = rect.top + rect.height / 2 - 60;
+      if (y < VIEWPORT_PADDING) y = VIEWPORT_PADDING;
+      // 600 is a generous height upper-bound (medium portrait = 392, large
+      // portrait = 504, plus shadow allowance). Clamp keeps the preview's
+      // top inside the viewport when the icon is near the bottom.
+      const maxY = viewportH - 600;
+      if (y > maxY) y = Math.max(VIEWPORT_PADDING, maxY);
+
+      setPosition({ x, y });
+    }
+    recompute();
+
+    // Reposition on scroll (the picker's item list is scrollable) or
+    // resize. `true` capture so we catch scroll on the inner list, not
+    // just window scroll.
+    window.addEventListener('scroll', recompute, true);
+    window.addEventListener('resize', recompute);
+    return () => {
+      window.removeEventListener('scroll', recompute, true);
+      window.removeEventListener('resize', recompute);
+    };
+  }, [anchorEl]);
+
+  if (!position) return null;
+
+  return (
+    <CardPreview
+      card={card}
+      cardCode={cardCode}
+      faceUp={true}
+      gameAssets={gameAssets}
+      mode="hover"
+      position={position}
+      onClose={onClose}
+    />
+  );
+}

--- a/app/src/components/load-picker/LoadPickerModal.test.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import type { Card, GameAssets } from '@cardtable2/shared';
 import {
   LoadPickerModal,
   type LoadPickerSelectHandler,
@@ -9,6 +10,78 @@ import {
   FIXTURE_LOADABLES,
   fixtureResolveDerivedItems,
 } from './LoadPickerModal.fixture';
+
+// `use-image` is consumed transitively via CardPreview when the popover
+// renders. Default-mock it so the image always reports loaded — avoids
+// jsdom Image() flakiness and keeps tests deterministic.
+vi.mock('use-image', () => ({
+  default: vi.fn(() => [{ width: 300, height: 400 }, 'loaded']),
+}));
+
+// Stub matchMedia. Default to hover-capable (desktop) to keep most tests
+// on the popover branch; specific tests override to false to drive the
+// touch / modal branch. Vitest jsdom doesn't ship matchMedia.
+function installMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches,
+    media: q,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(), // legacy
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  installMatchMedia(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Build a minimal GameAssets with the eight fixture cards present so the
+ * eye-icon branch can resolve images. We intentionally do NOT supply the
+ * full ct-pack data — `CardPreview` is happy with a `card.face` URL and
+ * the orientation lookup falls back to portrait.
+ */
+function makeGameAssets(): GameAssets {
+  const cards: Record<string, Card> = {};
+  const codes = [
+    'spider-man',
+    'iron-man',
+    'cap',
+    'black-widow',
+    'thor',
+    'hulk',
+    'strange',
+    'wasp',
+  ];
+  for (const code of codes) {
+    cards[code] = {
+      name: code,
+      type: 'hero',
+      face: `https://example/${code}.png`,
+    };
+  }
+  return {
+    packs: [],
+    cardTypes: { hero: { back: 'https://example/back.png' } },
+    cards,
+    cardSets: {},
+    tokens: {},
+    counters: {},
+    mats: {},
+    tokenTypes: {},
+    statusTypes: {},
+    modifierStats: {},
+    iconTypes: {},
+    orientationRules: [],
+  };
+}
 
 /**
  * Helper: render the picker open with the standard fixture and a fresh
@@ -222,5 +295,134 @@ describe('LoadPickerModal', () => {
     // Step-2 list has 3 items
     const lastList = list[list.length - 1];
     expect(within(lastList).getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  describe('card preview affordance (ct-87o)', () => {
+    it('shows an eye-icon button on each card row', async () => {
+      const { user } = renderPicker({ gameAssets: makeGameAssets() });
+      await user.click(screen.getByText('Single Card'));
+
+      // 8 fixture cards; each row gets a preview button.
+      const buttons = screen.getAllByRole('button', { name: /^Preview / });
+      expect(buttons.length).toBe(8);
+      // Specific card row resolved by testid.
+      expect(
+        screen.getByTestId('load-picker-card-preview-spider-man'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows eye icons when the card entry has been materialized into static (registry path)', () => {
+      // Production path: `loadablesRegistry.resolveEntry` materializes
+      // asset-pack-derived sources into static, preserving `derivedFrom`.
+      // The picker must detect either form. Build a one-entry fixture that
+      // looks like the post-registry shape.
+      const materialized = [
+        {
+          type: 'card',
+          label: 'Single Card',
+          mode: 'additive' as const,
+          source: {
+            kind: 'static' as const,
+            derivedFrom: 'all-cards' as const,
+            items: [
+              {
+                id: 'spider-man',
+                label: 'Spider-Man',
+                data: { code: 'spider-man' },
+              },
+              { id: 'hulk', label: 'Hulk', data: { code: 'hulk' } },
+            ],
+          },
+        },
+      ];
+      render(
+        <LoadPickerModal
+          open={true}
+          onClose={vi.fn()}
+          loadables={materialized}
+          presetType="card"
+          onSelectItem={vi.fn()}
+          gameAssets={makeGameAssets()}
+        />,
+      );
+
+      // 2 cards in the materialized fixture.
+      expect(screen.getAllByRole('button', { name: /^Preview / }).length).toBe(
+        2,
+      );
+    });
+
+    it('does NOT show eye-icon buttons for non-card loadables', async () => {
+      const { user } = renderPicker({ gameAssets: makeGameAssets() });
+      // Scenario is a static loadable, not asset-pack-derived/all-cards.
+      await user.click(screen.getByText('Scenario'));
+
+      expect(
+        screen.queryByRole('button', { name: /^Preview / }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT show eye-icon buttons when gameAssets is omitted', async () => {
+      // Even on the card entry, the host can omit gameAssets — picker
+      // gracefully hides the affordance instead of crashing.
+      const { user } = renderPicker({ gameAssets: null });
+      await user.click(screen.getByText('Single Card'));
+
+      expect(
+        screen.queryByRole('button', { name: /^Preview / }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('clicking the eye icon does NOT trigger row select', async () => {
+      const { user, onSelectItem } = renderPicker({
+        gameAssets: makeGameAssets(),
+      });
+      await user.click(screen.getByText('Single Card'));
+
+      await user.click(
+        screen.getByTestId('load-picker-card-preview-spider-man'),
+      );
+
+      // No selection fired — the eye icon stops propagation.
+      expect(onSelectItem).not.toHaveBeenCalled();
+    });
+
+    it('hover on eye icon shows the popover preview (desktop)', async () => {
+      installMatchMedia(true); // hover-capable
+      const { user } = renderPicker({ gameAssets: makeGameAssets() });
+      await user.click(screen.getByText('Single Card'));
+
+      // Initially no preview rendered.
+      expect(screen.queryByTestId('card-preview-hover')).toBeNull();
+
+      await user.hover(
+        screen.getByTestId('load-picker-card-preview-spider-man'),
+      );
+
+      // CardPreview's hover-mode root carries data-testid="card-preview-hover".
+      expect(screen.getByTestId('card-preview-hover')).toBeInTheDocument();
+
+      // Unhover dismisses it.
+      await user.unhover(
+        screen.getByTestId('load-picker-card-preview-spider-man'),
+      );
+      expect(screen.queryByTestId('card-preview-hover')).toBeNull();
+    });
+
+    it('tap on eye icon opens the full-screen modal (touch)', async () => {
+      installMatchMedia(false); // touch-only
+      const { user } = renderPicker({ gameAssets: makeGameAssets() });
+      await user.click(screen.getByText('Single Card'));
+
+      // No popover on touch — modal only.
+      expect(screen.queryByTestId('card-preview-hover')).toBeNull();
+
+      await user.click(
+        screen.getByTestId('load-picker-card-preview-spider-man'),
+      );
+
+      // FullScreenCardPreview carries data-testid="card-preview-modal".
+      expect(screen.getByTestId('card-preview-modal')).toBeInTheDocument();
+    });
   });
 });

--- a/app/src/components/load-picker/LoadPickerModal.test.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.test.tsx
@@ -47,6 +47,14 @@ describe('LoadPickerModal', () => {
     expect(screen.getByText('Single Card')).toBeInTheDocument();
   });
 
+  it('does not render the additive/replace mode badge in step 1 (ct-i4d)', () => {
+    renderPicker();
+    // Mode badge previously rendered the literal text 'additive' or
+    // 'replace' as plumbing detail — now removed.
+    expect(screen.queryByText(/^additive$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^replace$/i)).not.toBeInTheDocument();
+  });
+
   it('clicking a static type shows its items at step 2', async () => {
     const { user } = renderPicker();
     await user.click(screen.getByText('Scenario'));

--- a/app/src/components/load-picker/LoadPickerModal.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.tsx
@@ -325,12 +325,7 @@ function Step1TypeList({ loadables, onPickType }: Step1Props) {
             data-testid={`load-picker-type-${entry.type}`}
           >
             <div className="load-picker-type-label">{entry.label}</div>
-            <div className="load-picker-type-meta">
-              {describeSource(entry)}
-              <span className="load-picker-type-mode">
-                {entry.mode === 'replace' ? 'replace' : 'additive'}
-              </span>
-            </div>
+            <div className="load-picker-type-meta">{describeSource(entry)}</div>
           </button>
         </li>
       ))}

--- a/app/src/components/load-picker/LoadPickerModal.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { LoadableEntry, LoadableStaticItem } from '@cardtable2/shared';
+import type {
+  Card,
+  GameAssets,
+  LoadableEntry,
+  LoadableStaticItem,
+} from '@cardtable2/shared';
 import { fuzzySearch } from '../../utils/fuzzySearch';
+import { FullScreenCardPreview } from '../FullScreenCardPreview';
+import { CardPreviewPopover } from './CardPreviewPopover';
+import { useHoverCapable } from './useHoverCapable';
 
 /**
  * Cap on the number of items rendered for asset-pack-derived sources to
@@ -68,6 +76,15 @@ interface LoadPickerModalProps {
    * those entries.
    */
   resolveDerivedItems?: DerivedItemsResolver;
+  /**
+   * Active game assets — required to render the per-row card-image
+   * preview affordance (eye icon) on `asset-pack-derived` /
+   * `derivation: 'all-cards'` entries (ct-87o). Optional because the
+   * picker is also used for scenarios / encounter sets / decks where no
+   * preview is shown, and tests without a plugin loaded omit it. When
+   * absent, the picker simply doesn't render the eye icon.
+   */
+  gameAssets?: GameAssets | null;
 }
 
 /**
@@ -93,6 +110,7 @@ export function LoadPickerModal({
   presetType,
   onSelectItem,
   resolveDerivedItems,
+  gameAssets,
 }: LoadPickerModalProps) {
   const presetEntry = useMemo(
     () =>
@@ -207,6 +225,22 @@ export function LoadPickerModal({
     handleClose();
   };
 
+  // Card-image preview affordance is only meaningful for the "Card"
+  // loadable: scenarios / decks / encounter sets are loaded as a unit and
+  // don't have a single previewable image. We key off the source
+  // provenance — either a still-derived `asset-pack-derived` /
+  // `all-cards`, or a materialized `static` whose `derivedFrom` is
+  // `all-cards` (the registry materializes derived sources at populate
+  // time; see `loadablesRegistry.resolveEntry`). Both paths converge to
+  // items shaped `{ code: string }`, which is what the eye icon needs.
+  // Crucially we don't key off plugin-defined `type` strings (ct-87o).
+  const isCardEntry =
+    activeEntry !== null &&
+    ((activeEntry.source.kind === 'asset-pack-derived' &&
+      activeEntry.source.derivation === 'all-cards') ||
+      (activeEntry.source.kind === 'static' &&
+        activeEntry.source.derivedFrom === 'all-cards'));
+
   // Backdrop click — only close if the click landed on the backdrop
   // itself, not on the panel.  Prevents accidental closes when the
   // user releases a drag started inside the panel.
@@ -289,6 +323,8 @@ export function LoadPickerModal({
             query={query}
             onQueryChange={setQuery}
             onPickItem={handlePickItem}
+            isCardEntry={isCardEntry}
+            gameAssets={gameAssets ?? null}
           />
         )}
       </div>
@@ -351,6 +387,44 @@ interface Step2Props {
   query: string;
   onQueryChange: (q: string) => void;
   onPickItem: (item: LoadPickerItem) => void;
+  /**
+   * True when the active loadable is the card-image entry (asset-pack
+   * derived, 'all-cards'). Drives the per-row eye-icon affordance.
+   */
+  isCardEntry: boolean;
+  /**
+   * Game assets for resolving card images. Only consulted when
+   * `isCardEntry` is true. Null is tolerated — the eye icon is hidden.
+   */
+  gameAssets: GameAssets | null;
+}
+
+/**
+ * Per-row card-image preview state. We track the picker item that was
+ * activated plus the icon element that anchored the popover; both are
+ * needed because:
+ *
+ *   - the item gives us `data.code` to resolve the `Card`;
+ *   - the anchor gives the popover a stable position to flip / clamp
+ *     against, even when the list scrolls.
+ */
+interface PreviewState {
+  item: LoadPickerItem;
+  anchor: HTMLElement;
+}
+
+/**
+ * Read a `{ code: string }` payload off a picker item, returning `null`
+ * if the shape doesn't match. The `LoadPickerItem.data` field is `unknown`
+ * by design (the picker stays generic over scenarios / decks / cards).
+ * Asset-pack-derived 'all-cards' items always carry `{ code }` per
+ * `loadablesRegistry.deriveItems`, but a defensive narrowing keeps the
+ * types honest for tests and unforeseen callers.
+ */
+function readCardCode(data: unknown): string | null {
+  if (data === null || typeof data !== 'object') return null;
+  const code = (data as { code?: unknown }).code;
+  return typeof code === 'string' ? code : null;
 }
 
 // Provider-source entries auto-fire from the modal-level effect (ct-yj2);
@@ -361,8 +435,37 @@ function Step2ItemList({
   query,
   onQueryChange,
   onPickItem,
+  isCardEntry,
+  gameAssets,
 }: Step2Props) {
   const showingCappedHint = !query.trim() && totalItems > items.length;
+  const hoverCapable = useHoverCapable();
+
+  // The *currently shown* preview, regardless of mode. On hover-capable
+  // devices it's set/cleared by mouseenter/leave on the eye icon; on
+  // touch devices it's set by clicking the icon and cleared by closing
+  // the modal. Storing the anchor element lets the popover follow the
+  // icon on scroll without an extra ref-by-id lookup.
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  // Resolving "what to render" is shared between hover and touch paths.
+  // We tolerate a missing card (asset pack hasn't loaded the entry yet)
+  // by skipping render — the eye icon stays visible but does nothing.
+  const previewCard: { card: Card; cardCode: string } | null = useMemo(() => {
+    if (!preview || !gameAssets) return null;
+    const code = readCardCode(preview.item.data);
+    if (code === null) return null;
+    const card = gameAssets.cards[code];
+    if (!card) return null;
+    return { card, cardCode: code };
+  }, [preview, gameAssets]);
+
+  // Card-image preview shows the eye icon only when:
+  //   - the active loadable is the card entry, AND
+  //   - the host supplied gameAssets (otherwise we can't resolve images).
+  // Both conditions are checked at the row level for correctness when a
+  // host re-renders the picker mid-flow.
+  const showEyeIcon = isCardEntry && gameAssets !== null;
 
   if (totalItems === 0) {
     return <div className="load-picker-empty">No items available</div>;
@@ -388,6 +491,11 @@ function Step2ItemList({
         // row as a list item AND a button (ct-rde). Empty-match state
         // renders a plain message instead of an empty list to avoid an
         // <ul> with zero <li> children.
+        //
+        // For card entries the row also gets a sibling eye-icon button.
+        // Sibling (not nested) so we don't produce invalid HTML
+        // (button-in-button) and so each control has its own
+        // accessibility tree node.
         <ul
           className="load-picker-items"
           aria-label="Items"
@@ -403,6 +511,15 @@ function Step2ItemList({
               >
                 {it.label}
               </button>
+              {showEyeIcon && (
+                <CardPreviewIconButton
+                  item={it}
+                  hoverCapable={hoverCapable}
+                  onHoverIn={(anchor) => setPreview({ item: it, anchor })}
+                  onHoverOut={() => setPreview(null)}
+                  onTap={(anchor) => setPreview({ item: it, anchor })}
+                />
+              )}
             </li>
           ))}
         </ul>
@@ -414,6 +531,117 @@ function Step2ItemList({
           to narrow.
         </div>
       )}
+
+      {/*
+        Two preview surfaces — both are conditional on:
+          1. `preview` being set (a row was activated),
+          2. `previewCard` resolving (gameAssets present, card found).
+        Hover-capable devices get the popover; touch devices get the
+        full-screen modal. The hook flips reactively if the device's
+        capabilities change mid-session (rare but possible — e.g. user
+        unplugs a mouse).
+       */}
+      {preview && previewCard && hoverCapable && gameAssets && (
+        <CardPreviewPopover
+          card={previewCard.card}
+          cardCode={previewCard.cardCode}
+          gameAssets={gameAssets}
+          anchorEl={preview.anchor}
+          onClose={() => setPreview(null)}
+        />
+      )}
+      {preview && previewCard && !hoverCapable && gameAssets && (
+        <FullScreenCardPreview
+          card={previewCard.card}
+          cardCode={previewCard.cardCode}
+          faceUp={true}
+          gameAssets={gameAssets}
+          onClose={() => setPreview(null)}
+        />
+      )}
     </div>
+  );
+}
+
+interface CardPreviewIconButtonProps {
+  item: LoadPickerItem;
+  hoverCapable: boolean;
+  onHoverIn: (anchor: HTMLElement) => void;
+  onHoverOut: () => void;
+  onTap: (anchor: HTMLElement) => void;
+}
+
+/**
+ * Eye-icon button rendered alongside each card row. Stops click
+ * propagation so the row's "select item" handler doesn't fire — the
+ * affordance is preview-only (per the bd description, no click-to-pin
+ * v1). On hover-capable devices the icon doesn't *do* anything on click;
+ * the preview is purely hover-driven. On touch devices, click opens the
+ * full-screen modal.
+ */
+function CardPreviewIconButton({
+  item,
+  hoverCapable,
+  onHoverIn,
+  onHoverOut,
+  onTap,
+}: CardPreviewIconButtonProps) {
+  return (
+    <button
+      type="button"
+      className="load-picker-card-preview-btn"
+      aria-label={`Preview ${item.label}`}
+      data-testid={`load-picker-card-preview-${item.id}`}
+      onClick={(e) => {
+        // Always block the row select; the icon is its own affordance.
+        e.stopPropagation();
+        if (!hoverCapable) {
+          onTap(e.currentTarget);
+        }
+      }}
+      onMouseEnter={(e) => {
+        if (hoverCapable) onHoverIn(e.currentTarget);
+      }}
+      onMouseLeave={() => {
+        if (hoverCapable) onHoverOut();
+      }}
+      onFocus={(e) => {
+        // Keyboard-tab parity with hover: focusing the icon shows the
+        // popover on hover-capable devices. On touch devices we don't
+        // auto-open from focus (would clash with tap-to-open).
+        if (hoverCapable) onHoverIn(e.currentTarget);
+      }}
+      onBlur={() => {
+        if (hoverCapable) onHoverOut();
+      }}
+    >
+      <EyeIcon />
+    </button>
+  );
+}
+
+/**
+ * Inline eye SVG — kept out of an icon library because we use exactly
+ * one icon and the project doesn't currently depend on lucide / heroicons
+ * via a per-component import path. `aria-hidden` because the parent
+ * button carries the accessible label.
+ */
+function EyeIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
   );
 }

--- a/app/src/components/load-picker/LoadPickerModal.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.tsx
@@ -378,7 +378,7 @@ function describeSource(entry: LoadableEntry): string {
   if (source.kind === 'asset-pack-derived') {
     return source.derivation === 'all-cards' ? 'All cards' : 'All card sets';
   }
-  return 'Provider';
+  return source.config?.labels?.siteName ?? 'External import';
 }
 
 interface Step2Props {

--- a/app/src/components/load-picker/useHoverCapable.test.ts
+++ b/app/src/components/load-picker/useHoverCapable.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useHoverCapable } from './useHoverCapable';
+
+interface MqlMock {
+  matches: boolean;
+  media: string;
+  onchange: null;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  dispatchEvent: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Build a controllable matchMedia mock. Returns the MQL stub so tests
+ * can fire its 'change' listener and toggle `matches` mid-flight to
+ * verify the hook reacts to capability changes.
+ */
+function setupMatchMedia(initialMatches: boolean): MqlMock {
+  const mql: MqlMock = {
+    matches: initialMatches,
+    media: '',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+  window.matchMedia = vi.fn().mockImplementation((q: string) => {
+    mql.media = q;
+    return mql;
+  });
+  return mql;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useHoverCapable', () => {
+  it('returns true when the media query matches', () => {
+    setupMatchMedia(true);
+    const { result } = renderHook(() => useHoverCapable());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the media query does not match', () => {
+    setupMatchMedia(false);
+    const { result } = renderHook(() => useHoverCapable());
+    expect(result.current).toBe(false);
+  });
+
+  it('reactively updates when the media query changes', () => {
+    const mql = setupMatchMedia(false);
+    const { result } = renderHook(() => useHoverCapable());
+    expect(result.current).toBe(false);
+
+    // Find the change handler the hook subscribed with.
+    expect(mql.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+    const changeHandler = mql.addEventListener.mock.calls[0][1] as (
+      e: MediaQueryListEvent,
+    ) => void;
+
+    act(() => {
+      changeHandler({ matches: true } as MediaQueryListEvent);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      changeHandler({ matches: false } as MediaQueryListEvent);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false defensively when matchMedia is unavailable', () => {
+    // Some non-browser environments (older jsdom without polyfill, SSR)
+    // lack matchMedia. The hook should not throw, and defaulting to
+    // touch (false) gives a usable modal instead of an orphan popover.
+    const original = window.matchMedia;
+    // Casting to never lets us delete on the typed window without
+    // disabling no-explicit-any; we restore in afterEach.
+    (window as { matchMedia?: typeof window.matchMedia }).matchMedia =
+      undefined;
+    const { result } = renderHook(() => useHoverCapable());
+    expect(result.current).toBe(false);
+    window.matchMedia = original;
+  });
+
+  it('cleans up the change listener on unmount', () => {
+    const mql = setupMatchMedia(true);
+    const { unmount } = renderHook(() => useHoverCapable());
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+  });
+});

--- a/app/src/components/load-picker/useHoverCapable.ts
+++ b/app/src/components/load-picker/useHoverCapable.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reactive `(hover: hover) and (pointer: fine)` media-query check.
+ *
+ * Returns `true` on devices where the primary pointer can hover with fine
+ * precision (typical desktop mouse / trackpad). Returns `false` on
+ * touch-primary devices (most phones / tablets) where hover is unreliable
+ * and tap is the right interaction.
+ *
+ * Used by the load picker to choose between a hover popover (desktop) and
+ * a full-screen modal (touch) for the card-image preview affordance
+ * (ct-87o). Picker rows are visible on both — only the activation
+ * mechanism switches.
+ *
+ * Defensive against `matchMedia` being absent (older jsdom in unit tests
+ * without an explicit polyfill, server-side render): returns `false`,
+ * which gives the touch-style modal — safer default than a phantom
+ * popover with no way to dismiss.
+ */
+export function useHoverCapable(): boolean {
+  // Initialize from the media query if available; otherwise assume not
+  // hover-capable. The state is updated lazily — most consumers only need
+  // the first render's value, but a user dragging a window between a
+  // touch screen and a mouse-driven monitor will see the value flip.
+  const [hoverCapable, setHoverCapable] = useState<boolean>(() =>
+    readHoverCapable(),
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(hover: hover) and (pointer: fine)');
+    const handler = (e: MediaQueryListEvent) => {
+      setHoverCapable(e.matches);
+    };
+    // Sync once on mount in case the value changed between SSR and hydrate.
+    setHoverCapable(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return hoverCapable;
+}
+
+function readHoverCapable(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+}

--- a/app/src/content/loadablesRegistry.ts
+++ b/app/src/content/loadablesRegistry.ts
@@ -166,7 +166,11 @@ function resolveEntry(
   const items = deriveItems(source.derivation, gameAssets);
   return {
     ...entry,
-    source: { kind: 'static', items },
+    // Preserve `derivedFrom` so the picker UI can re-detect that this was
+    // originally `all-cards` (and render the per-row card-image preview
+    // affordance) without depending on plugin-defined `type` strings
+    // (ct-87o).
+    source: { kind: 'static', items, derivedFrom: source.derivation },
   };
 }
 

--- a/app/src/hooks/useDevMode.test.ts
+++ b/app/src/hooks/useDevMode.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDevMode, DEV_MODE_STORAGE_KEY } from './useDevMode';
+
+describe('useDevMode', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts disabled when no persisted value exists', () => {
+    const { result } = renderHook(() => useDevMode());
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it('starts enabled when localStorage has dev-mode persisted', () => {
+    window.localStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useDevMode());
+    expect(result.current.enabled).toBe(true);
+  });
+
+  it('treats non-"true" persisted values as disabled', () => {
+    window.localStorage.setItem(DEV_MODE_STORAGE_KEY, 'yes');
+    const { result } = renderHook(() => useDevMode());
+    expect(result.current.enabled).toBe(false);
+  });
+
+  it('flips enabled to true and persists when enable() fires', () => {
+    const { result } = renderHook(() => useDevMode());
+    expect(result.current.enabled).toBe(false);
+
+    act(() => {
+      result.current.enable();
+    });
+
+    expect(result.current.enabled).toBe(true);
+    expect(window.localStorage.getItem(DEV_MODE_STORAGE_KEY)).toBe('true');
+  });
+
+  it('enable() is idempotent', () => {
+    const { result } = renderHook(() => useDevMode());
+
+    act(() => {
+      result.current.enable();
+      result.current.enable();
+    });
+
+    expect(result.current.enabled).toBe(true);
+    expect(window.localStorage.getItem(DEV_MODE_STORAGE_KEY)).toBe('true');
+  });
+});

--- a/app/src/hooks/useDevMode.ts
+++ b/app/src/hooks/useDevMode.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * localStorage key under which the persisted dev-mode flag is stored.
+ *
+ * Exported so tests (and any future callers that need to seed/clear
+ * the value) can reference the same key without duplicating the string.
+ */
+export const DEV_MODE_STORAGE_KEY = 'cardtable2:dev-mode';
+
+interface UseDevModeReturn {
+  /** Whether dev-mode is currently enabled (persisted across reloads). */
+  enabled: boolean;
+  /**
+   * Persist dev-mode = true and update local state. Idempotent — calling
+   * after dev-mode is already enabled is a no-op.
+   *
+   * v1 has no `disable()` by design (per ct-824); turning it off requires
+   * clearing localStorage manually. We can revisit if a UX need arises.
+   */
+  enable: () => void;
+}
+
+const readPersisted = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(DEV_MODE_STORAGE_KEY) === 'true';
+  } catch {
+    // Reading localStorage can throw in restrictive environments
+    // (e.g. Safari private mode, sandboxed iframes). Fall back to off.
+    return false;
+  }
+};
+
+/**
+ * Persisted "dev-mode" toggle. Currently consumed by the home screen
+ * (`app/src/routes/index.tsx`) to gate the "Load from local directory…"
+ * button in production builds — see ct-824. The Konami listener calls
+ * `enable()` when fired; reads on mount restore prior state across reloads.
+ */
+export function useDevMode(): UseDevModeReturn {
+  const [enabled, setEnabled] = useState<boolean>(readPersisted);
+
+  const enable = useCallback(() => {
+    try {
+      window.localStorage.setItem(DEV_MODE_STORAGE_KEY, 'true');
+    } catch {
+      // Persistence failure is non-fatal — still flip the in-memory flag
+      // so the UI reveals for this session.
+    }
+    setEnabled(true);
+  }, []);
+
+  return { enabled, enable };
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1527,6 +1527,21 @@ h1 {
   letter-spacing: 0.02em;
 }
 
+.local-plugin-button__dev-tag {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 0.25rem;
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  color: rgba(199, 210, 254, 0.95);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 /* Loading Skeleton */
 @keyframes skeleton-shimmer {
   0% {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2171,16 +2171,6 @@ h1 {
   gap: 0.5rem;
 }
 
-.load-picker-type-mode {
-  font-size: 0.6875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: rgba(255, 255, 255, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.25rem;
-  padding: 0.0625rem 0.375rem;
-}
-
 .load-picker-step2 {
   display: flex;
   flex-direction: column;

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2230,10 +2230,50 @@ h1 {
 
 .load-picker-items-item {
   display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
 }
 
 .load-picker-items-item > .load-picker-item {
   flex: 1;
+}
+
+/*
+ * Eye-icon affordance for card rows (ct-87o). Sibling button to the row
+ * select; its onClick stops propagation so tapping the eye doesn't load
+ * the card. Matches the row's vertical rhythm; the icon's color picks
+ * up the row text color via currentColor.
+ */
+.load-picker-card-preview-btn {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  padding: 0 0.5rem;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+  flex-shrink: 0;
+}
+
+.load-picker-card-preview-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.load-picker-card-preview-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.7);
+  border-color: rgba(99, 102, 241, 0.6);
+  color: white;
 }
 
 .load-picker-item {

--- a/app/src/renderer/handlers/coordinates.test.ts
+++ b/app/src/renderer/handlers/coordinates.test.ts
@@ -7,17 +7,30 @@ import type { RendererContext } from '../RendererContext';
 import { handleRequestViewportState } from './coordinates';
 
 /**
- * Build a minimal RendererContext for handleRequestViewportState (ct-rde).
+ * Build a minimal RendererContext for handleRequestViewportState (ct-rde, ct-t9z).
  *
  * The handler only reads: worldContainer.position, app.screen.{width,height},
  * coordConverter.{getCameraScale, getDevicePixelRatio}, and posts a single
  * `viewport-state` response. We deliberately stub only that slice.
+ *
+ * IMPORTANT (ct-t9z): in this app PixiJS is initialised with
+ *   `app.init({ width: clientWidth * dpr, height: clientHeight * dpr,
+ *               resolution: dpr, autoDensity: true })`
+ * (see `useCanvasLifecycle.ts` + `RendererOrchestrator.initialize`). That makes
+ * `app.screen.width/height` and `worldContainer.position` carry PHYSICAL
+ * (canvas) pixels — NOT CSS pixels. The fixtures below mirror that physical-px
+ * convention so the unit tests match what the live renderer actually feeds
+ * the handler.
  */
 function buildContext(opts: {
+  /** worldContainer.position.x in physical (canvas) pixels. */
   worldX: number;
+  /** worldContainer.position.y in physical (canvas) pixels. */
   worldY: number;
   scale: number;
+  /** app.screen.width in physical pixels (= clientWidth * dpr in this app). */
   screenWidth: number;
+  /** app.screen.height in physical pixels (= clientHeight * dpr in this app). */
   screenHeight: number;
   dpr: number;
 }): {
@@ -45,17 +58,20 @@ const requestMessage = {
   type: 'request-viewport-state',
 } as Extract<MainToRendererMessage, { type: 'request-viewport-state' }>;
 
-describe('handleRequestViewportState (ct-rde)', () => {
-  it('reports viewport dimensions in CSS pixels (app.screen, not app.renderer)', () => {
+describe('handleRequestViewportState (ct-rde, ct-t9z)', () => {
+  it('divides BOTH camera position AND viewport dims by DPR to produce CSS-pixel output', () => {
     // Retina-style display: CSS 800x600, canvas buffer 1600x1200.
-    // worldContainer.position.x is set by CameraManager.initialize from
-    // app.renderer.width/2, so it sits at 800 in canvas-pixel space.
+    // Both worldContainer.position and app.screen carry PHYSICAL px in this
+    // app (because `app.init` was called with width=clientWidth*dpr,
+    // resolution=dpr — see ct-t9z root cause analysis).
+    // CameraManager.initialize set worldContainer.position to
+    // (app.renderer.width/2, app.renderer.height/2) = (800, 600) physical.
     const { context, postResponse } = buildContext({
-      worldX: 800,
-      worldY: 600,
+      worldX: 800, // physical px
+      worldY: 600, // physical px
       scale: 1,
-      screenWidth: 800,
-      screenHeight: 600,
+      screenWidth: 1600, // physical px (= 800 CSS × 2 DPR)
+      screenHeight: 1200, // physical px (= 600 CSS × 2 DPR)
       dpr: 2,
     });
 
@@ -67,8 +83,8 @@ describe('handleRequestViewportState (ct-rde)', () => {
       cameraX: 400, // 800 / 2 → CSS pixels
       cameraY: 300, // 600 / 2 → CSS pixels
       cameraScale: 1,
-      viewportWidth: 800,
-      viewportHeight: 600,
+      viewportWidth: 800, // 1600 / 2 → CSS pixels (ct-t9z: was 1600 before fix)
+      viewportHeight: 600, // 1200 / 2 → CSS pixels (ct-t9z: was 1200 before fix)
       devicePixelRatio: 2,
     });
   });
@@ -78,8 +94,12 @@ describe('handleRequestViewportState (ct-rde)', () => {
     // must produce equal cameraX/Y and viewportWidth/Height; only DPR
     // differs. This is the property the placement primitive relies on for
     // viewport-center to land in the same world position regardless of DPR.
+    //
+    // In this app the renderer-side values scale with DPR (because of how
+    // `app.init` is called — see buildContext doc), so dpr=2 inputs are 2×
+    // their dpr=1 counterparts; after the /dpr in the handler they collapse.
     const dpr1 = buildContext({
-      worldX: 600, // canvas pixels (DPR 1 → identical to CSS)
+      worldX: 600, // physical px (= CSS at DPR 1)
       worldY: 400,
       scale: 1.5,
       screenWidth: 1200,
@@ -87,11 +107,11 @@ describe('handleRequestViewportState (ct-rde)', () => {
       dpr: 1,
     });
     const dpr2 = buildContext({
-      worldX: 1200, // canvas pixels (DPR 2 → 2× the CSS value)
+      worldX: 1200, // physical px (= 2× CSS at DPR 2)
       worldY: 800,
       scale: 1.5,
-      screenWidth: 1200,
-      screenHeight: 800,
+      screenWidth: 2400, // physical px (= 1200 CSS × 2 DPR)
+      screenHeight: 1600,
       dpr: 2,
     });
 
@@ -118,5 +138,100 @@ describe('handleRequestViewportState (ct-rde)', () => {
     // the renderer's canvas-pixel world space when storing object positions.
     expect(call1.devicePixelRatio).toBe(1);
     expect(call2.devicePixelRatio).toBe(2);
+  });
+
+  it('post-pan: viewport-state still yields a world centre at the new CSS centre (ct-t9z)', () => {
+    // Setup: CSS 800x600 viewport on a DPR=2 display.
+    //   app.screen = (1600, 1200) physical px
+    //   worldContainer.position (post-init) = (800, 600) physical px
+    // The user pans by (+200, -100) physical px (see
+    // `app/src/hooks/usePointerEvents.ts` — clientX deltas are multiplied by
+    // DPR before being fed to the renderer, so `camera.pan` operates in
+    // physical px and the position stays in a single unit system).
+    //   worldContainer.position = (1000, 500) physical px.
+    //
+    // The viewport-state handler must produce a snapshot the placement
+    // primitive can pair with viewport dims to yield a world coord that
+    // renders at the post-pan canvas centre when the consumer scales back
+    // by DPR.
+    const { context, postResponse } = buildContext({
+      worldX: 1000, // 800 + 200 pan
+      worldY: 500, // 600 - 100 pan
+      scale: 1,
+      screenWidth: 1600,
+      screenHeight: 1200,
+      dpr: 2,
+    });
+    handleRequestViewportState(requestMessage, context);
+    const call = postResponse.mock.calls[0][0] as Extract<
+      RendererToMainMessage,
+      { type: 'viewport-state' }
+    >;
+    // All values in CSS px:
+    expect(call.cameraX).toBe(500);
+    expect(call.cameraY).toBe(250);
+    expect(call.viewportWidth).toBe(800);
+    expect(call.viewportHeight).toBe(600);
+    expect(call.cameraScale).toBe(1);
+
+    // Pair with the placement util to verify the world coord
+    // round-trips to a stage position equal to the canvas CSS centre.
+    // Placement (no jitter) → world = ((800/2 - 500)/1, (600/2 - 250)/1)
+    //                              = (-100, 50) in CSS px.
+    // Consumer multiplies by DPR=2 → _pos = (-200, 100) physical px.
+    // visual stage position = (1000 + -200, 500 + 100) = (800, 600).
+    // CSS = (800/2, 600/2) = (400, 300) — exactly canvas CSS centre ✓.
+    const placement = {
+      x: (call.viewportWidth / 2 - call.cameraX) / call.cameraScale,
+      y: (call.viewportHeight / 2 - call.cameraY) / call.cameraScale,
+    };
+    const worldStorePos = {
+      x: placement.x * call.devicePixelRatio,
+      y: placement.y * call.devicePixelRatio,
+    };
+    const stageXAfterAdd = context.worldContainer.position.x + worldStorePos.x;
+    const stageYAfterAdd = context.worldContainer.position.y + worldStorePos.y;
+    expect(stageXAfterAdd / call.devicePixelRatio).toBe(400); // canvas CSS centre x
+    expect(stageYAfterAdd / call.devicePixelRatio).toBe(300); // canvas CSS centre y
+  });
+
+  it('post-zoom: viewport-state still yields a world centre at the canvas CSS centre (ct-t9z)', () => {
+    // Setup: CSS 800x600 on DPR=2, then the user wheels-zoomed to scale=1.5
+    // with mouse anchored at canvas centre. Per CameraManager.zoom:
+    //   worldContainer.position.x = mouseX - worldPoint.x * newScale
+    // where mouseX is in physical px (Board.tsx forwards a DPR-multiplied
+    // clientX). With mouse at canvas centre and worldPoint at (0, 0):
+    //   position = (canvasCentrePhysical.x, canvasCentrePhysical.y) = (800, 600)
+    // (scale doesn't shift it because worldPoint = 0).
+    // We assert the placement still lands at canvas CSS centre.
+    const { context, postResponse } = buildContext({
+      worldX: 800,
+      worldY: 600,
+      scale: 1.5,
+      screenWidth: 1600,
+      screenHeight: 1200,
+      dpr: 2,
+    });
+    handleRequestViewportState(requestMessage, context);
+    const call = postResponse.mock.calls[0][0] as Extract<
+      RendererToMainMessage,
+      { type: 'viewport-state' }
+    >;
+    expect(call.cameraX).toBe(400);
+    expect(call.cameraY).toBe(300);
+    expect(call.viewportWidth).toBe(800);
+    expect(call.viewportHeight).toBe(600);
+    expect(call.cameraScale).toBe(1.5);
+
+    // Placement: world = ((800/2 - 400)/1.5, (600/2 - 300)/1.5) = (0, 0).
+    // Consumer multiplies by DPR=2 → _pos = (0, 0).
+    // visual stage position = (800 + 0*1.5, 600 + 0*1.5) = (800, 600).
+    // CSS = (400, 300) — canvas CSS centre ✓.
+    const placement = {
+      x: (call.viewportWidth / 2 - call.cameraX) / call.cameraScale,
+      y: (call.viewportHeight / 2 - call.cameraY) / call.cameraScale,
+    };
+    expect(placement.x).toBe(0);
+    expect(placement.y).toBe(0);
   });
 });

--- a/app/src/renderer/handlers/coordinates.ts
+++ b/app/src/renderer/handlers/coordinates.ts
@@ -109,18 +109,26 @@ export function handleRequestScreenCoords(
  * `MainToRendererMessage.viewport-state` and the `ViewportState` shape the
  * placement primitive consumes.
  *
- * The renderer internally tracks `worldContainer.position` and
- * `app.renderer.width/height` in physical canvas pixels (CSS × DPR — see
- * `CameraManager.initialize`). On non-1.0 DPR displays sourcing the response
- * straight from those buffers leaks DPR-scaled values across the boundary,
- * which made the documented "CSS pixels" promise a lie. We divide camera
- * position by DPR and source viewport dimensions from `app.screen` (PixiJS's
- * CSS-pixel mirror of the canvas) so the placement primitive gets a
- * consistent CSS-pixel snapshot. The consumer (`runStaticLoadable` /
- * `runProviderLoadable` in `app/src/content/loadHandler.ts`) scales the
- * resulting world coord back up by `devicePixelRatio` before storing the
- * object's `_pos`, since the renderer otherwise expects positions in its
- * native canvas-pixel world space.
+ * Unit care (ct-t9z): the renderer is initialised with PixiJS as
+ *   `app.init({ width: clientWidth * dpr, height: clientHeight * dpr,
+ *               resolution: dpr, autoDensity: true, … })`
+ * (see `useCanvasLifecycle.ts` and `RendererOrchestrator.initialize`). With
+ * that config PixiJS's "stage units" (which is what `app.screen.width/height`
+ * and `worldContainer.position` carry) equal physical canvas pixels — NOT CSS
+ * pixels. `CameraManager.initialize` sets `worldContainer.position` from
+ * `app.renderer.width/height` (also physical px), so both inputs to this
+ * handler live in the same physical-px coordinate system. To honour the
+ * documented "CSS pixels" contract we must divide ALL of them by DPR — both
+ * the camera position AND the viewport dimensions. The earlier ct-rde version
+ * only divided the camera position, leaving viewport dims in physical px, so
+ * the placement primitive computed a world point that was DPR× too far from
+ * centre and additive loads landed near the canvas bottom-right corner on
+ * retina displays.
+ *
+ * The consumer (`handleLoadSelection` in `app/src/content/loadHandler.ts`)
+ * scales the resulting world coord back up by `devicePixelRatio` before
+ * storing the object's `_pos`, since the renderer otherwise expects positions
+ * in its native stage-unit world space.
  */
 export function handleRequestViewportState(
   _message: Extract<MainToRendererMessage, { type: 'request-viewport-state' }>,
@@ -132,8 +140,8 @@ export function handleRequestViewportState(
     cameraX: context.worldContainer.position.x / dpr,
     cameraY: context.worldContainer.position.y / dpr,
     cameraScale: context.coordConverter.getCameraScale(),
-    viewportWidth: context.app.screen.width,
-    viewportHeight: context.app.screen.height,
+    viewportWidth: context.app.screen.width / dpr,
+    viewportHeight: context.app.screen.height / dpr,
     devicePixelRatio: dpr,
   });
 }

--- a/app/src/routes/dev.table.$id.tsx
+++ b/app/src/routes/dev.table.$id.tsx
@@ -496,6 +496,7 @@ function DevTable() {
         presetType={loadPicker.presetType}
         onSelectItem={handleLoadPickerSelect}
         resolveDerivedItems={resolveDerivedItems}
+        gameAssets={gameAssets}
       />
     </div>
   );

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -7,6 +7,7 @@ import {
   Config,
 } from 'unique-names-generator';
 import { useState, useEffect } from 'react';
+import { useKonami } from 'react-konami-code';
 import GameSelector from '../components/GameSelector';
 import {
   loadPluginRegistry,
@@ -14,6 +15,7 @@ import {
 } from '../content/pluginLoader';
 import { loadLocalPluginAssets, setPendingLocalPlugin } from '../content';
 import { ACTION_LOAD_PLUGIN_DIRECTORY_FAILED } from '../constants/errorIds';
+import { useDevMode } from '../hooks/useDevMode';
 
 export const Route = createFileRoute('/')({
   component: GameSelect,
@@ -32,6 +34,20 @@ function GameSelect() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [attemptCount, setAttemptCount] = useState(0);
+
+  // Dev tools (the "Load from local directory…" button) are always
+  // visible in local Vite dev (`pnpm dev`). In production builds the
+  // button is hidden until the user enters the Konami code, at which
+  // point dev-mode is persisted in localStorage so it survives reloads.
+  // See ct-824.
+  const isLocalDev = import.meta.env.DEV;
+  const { enabled: konamiDevMode, enable: enableDevMode } = useDevMode();
+  useKonami(enableDevMode);
+  const showLocalDir = isLocalDev || konamiDevMode;
+  // Show the subtle "dev" indicator only when revealed via Konami in a
+  // production build — in `pnpm dev` the button itself already labels
+  // the feature as a dev tool, so a second tag adds noise.
+  const showKonamiIndicator = !isLocalDev && konamiDevMode;
 
   useEffect(() => {
     const loadGames = async () => {
@@ -171,23 +187,33 @@ function GameSelect() {
 
         <main className="game-select__main">
           <GameSelector games={games} onGameLaunch={handleGameLaunch} />
-          <button
-            type="button"
-            className="local-plugin-button"
-            onClick={() => {
-              void handleLoadLocalDirectory();
-            }}
-          >
-            <span className="local-plugin-button__icon" aria-hidden="true">
-              📁
-            </span>
-            <span className="local-plugin-button__label">
-              Load from local directory…
-            </span>
-            <span className="local-plugin-button__hint">
-              Dev: pick a plugin folder on disk
-            </span>
-          </button>
+          {showLocalDir && (
+            <button
+              type="button"
+              className="local-plugin-button"
+              onClick={() => {
+                void handleLoadLocalDirectory();
+              }}
+            >
+              <span className="local-plugin-button__icon" aria-hidden="true">
+                📁
+              </span>
+              <span className="local-plugin-button__label">
+                Load from local directory…
+                {showKonamiIndicator && (
+                  <span
+                    className="local-plugin-button__dev-tag"
+                    aria-label="dev mode"
+                  >
+                    dev
+                  </span>
+                )}
+              </span>
+              <span className="local-plugin-button__hint">
+                Dev: pick a plugin folder on disk
+              </span>
+            </button>
+          )}
         </main>
       </div>
     </div>

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -932,6 +932,7 @@ function Table() {
         presetType={loadPicker.presetType}
         onSelectItem={handleLoadPickerSelect}
         resolveDerivedItems={resolveDerivedItems}
+        gameAssets={gameAssets}
       />
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      react-konami-code:
+        specifier: ^2.3.0
+        version: 2.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       unique-names-generator:
         specifier: ^4.7.1
         version: 4.7.1
@@ -1204,56 +1207,67 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
@@ -3185,6 +3199,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-konami-code@2.3.0:
+    resolution: {integrity: sha512-9x90HnzstiMXs2kFS9cYsb5a+ojKEB/iC24uzNKCoE9znorLJwUcy98tjsiW2i5AHB05GuqIMTzV5RaDpVSThw==}
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -7434,6 +7454,12 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-konami-code@2.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   react-refresh@0.18.0: {}
 

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -300,6 +300,15 @@ export interface LoadableStaticItem<TData = unknown> {
 export interface LoadableStaticSource<TData = unknown> {
   kind: 'static';
   items: Array<LoadableStaticItem<TData>>;
+  /**
+   * Provenance marker preserved when an `asset-pack-derived` source is
+   * materialized into a static source by the host's loadables registry
+   * (ct-87o). Lets downstream UI tell "all-cards" items apart from
+   * arbitrary plugin-declared static items without leaking plugin-defined
+   * `type` strings into the picker logic. Absent for genuinely-static
+   * (manifest-declared) sources.
+   */
+  derivedFrom?: LoadableDerivation;
 }
 
 /**


### PR DESCRIPTION
## Summary

Five follow-on UX cleanups after the loadables system landed in #107.

- **ct-i4d** — Remove additive/replace mode badge from picker step 1. The mode was implementation-speak (additive vs replace) with no value to end users; the picker shows only label + item count now.
- **ct-824** — Gate "Load from local directory…" button behind Vite DEV mode by default, with Konami code (↑↑↓↓←→←→BA) activation in production. Persists via localStorage. New `useDevMode` hook + `react-konami-code` dependency.
- **ct-87o** — Card preview affordance in the "Load Card…" picker. Eye icon on each card row; hover (desktop) → popover near the cursor; tap (touch) → full-screen modal with blurred backdrop. Reuses existing `CardPreview` / `FullScreenCardPreview`. Adds optional `derivedFrom` provenance on `LoadableStaticSource` so the picker can detect the all-cards entry post-registry-materialization without hardcoding plugin-defined `type` strings.
- **ct-t9z** — Fix card load not landing at viewport center on retina displays. `app.screen.width/height` returns physical canvas pixels in this PixiJS config (`resolution: dpr, autoDensity: true`), not CSS pixels. The ct-rde fix divided `worldContainer.position` by DPR but missed `app.screen.*` — so the consumer paired CSS-px `cameraX` with physical-px `viewportWidth`, landing the card ~DPR× off-center. Fix: divide `app.screen.*` by DPR too. Two new regression tests cover post-pan and post-zoom.
- **ct-wjd** — Picker step 1 surfaces the provider's `siteName` (e.g. "MarvelCDB") instead of the implementation word "Provider".

## Test plan

- [ ] On Marvel Champions plugin: open "Load…" picker → step 1 shows "Player Deck / MarvelCDB" (not "/ Provider"); no mode badges anywhere; clicking deck type opens DeckImportModal directly.
- [ ] On testgame: "Load Card…" → eye icon visible on each card row. Hover an icon → preview popover renders near cursor. Click a row body → card lands near viewport center. Pan + zoom the camera, load another card → still lands near (new) viewport center, slight jitter.
- [ ] `vite dev` (DEV mode): "Load from local directory…" button visible on home screen. Production build (or simulating non-DEV): button hidden until the Konami code is typed; after Konami, button appears and persists across reload.
- [ ] `pnpm typecheck`, `pnpm -r run test`, `pnpm format:check`, `pnpm -r run lint` all green.