### PR TITLE
docs: correct Railway PR preview URL pattern (ct-2gi)

### DIFF
--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -30,7 +30,7 @@ GitHub Actions workflows and production hosting reference. Loaded on-demand — 
 
 - Creates Railway preview services per PR
 - Builds Docker images for both app and server
-- Provides unique URLs for testing (e.g., `cardtable2-pr-123.up.railway.app`)
+- Provides unique URLs for testing (app: `cardtable2-app-pr-{N}-prs.up.railway.app`, server: `cardtable2-server-pr-{N}-prs.up.railway.app`)
 - Only builds on first PR build or when package changes
 
 ### `cleanup-pr.yml` — Resource cleanup


### PR DESCRIPTION
## Summary
- Updates `docs/CI-CD.md` line 33 to reflect the actual Railway PR preview URL pattern: `cardtable2-{app|server}-pr-{N}-prs.up.railway.app`. The previous example (`cardtable2-pr-{N}.up.railway.app`) was missing both the service-name segment and the `-prs` suffix.
- Verified against PR #109 (both URLs return correctly; app at 200, server has /health).

## Test plan
- [x] One-line doc change; no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)