### PR TITLE
feat(content): counters loadable + plugin manifest registry (ct-209)

### DIFF
--- a/app/public/plugins/testgame/index.json
+++ b/app/public/plugins/testgame/index.json
@@ -48,6 +48,37 @@
         "kind": "asset-pack-derived",
         "derivation": "all-cards"
       }
+    },
+    {
+      "type": "counter",
+      "label": "Counter",
+      "mode": "additive",
+      "source": {
+        "kind": "static",
+        "items": [
+          {
+            "id": "damage",
+            "label": "Damage",
+            "data": {
+              "color": 15871769,
+              "text": "DMG",
+              "min": 0,
+              "max": 99,
+              "startingValue": 0
+            }
+          },
+          {
+            "id": "threat",
+            "label": "Threat",
+            "data": {
+              "color": 3447003,
+              "min": 0,
+              "max": 20,
+              "startingValue": 0
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/app/src/content/counterRegistry.test.ts
+++ b/app/src/content/counterRegistry.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+  CounterTypeDef,
+  GameAssets,
+  LoadableEntry,
+} from '@cardtable2/shared';
+import { COUNTER_LOADABLE_TYPE } from '@cardtable2/shared';
+import { setLoadableEntries, clearLoadableEntries } from './loadablesRegistry';
+import {
+  parseCounterTypeDef,
+  getCounterTypeDef,
+  getAllCounterTypeDefs,
+} from './counterRegistry';
+
+function createGameAssets(overrides: Partial<GameAssets> = {}): GameAssets {
+  return {
+    packs: [],
+    cardTypes: {},
+    cards: {},
+    cardSets: {},
+    tokens: {},
+    counters: {},
+    mats: {},
+    tokenTypes: {},
+    statusTypes: {},
+    modifierStats: {},
+    iconTypes: {},
+    ...overrides,
+  };
+}
+
+function counterEntry(
+  items: Array<{ id: string; label: string; data: unknown }>,
+): LoadableEntry<unknown> {
+  return {
+    type: COUNTER_LOADABLE_TYPE,
+    label: 'Counter',
+    mode: 'additive',
+    source: { kind: 'static', items },
+  };
+}
+
+const validDef: CounterTypeDef = {
+  color: 0xf39c12,
+  text: 'DMG',
+  min: 0,
+  max: 99,
+  startingValue: 0,
+};
+
+describe('parseCounterTypeDef', () => {
+  it('accepts a fully populated definition', () => {
+    const parsed = parseCounterTypeDef(
+      {
+        color: 0xff0000,
+        text: 'DMG',
+        img: 'damage.png',
+        min: 0,
+        max: 50,
+        startingValue: 3,
+      },
+      'test',
+    );
+    expect(parsed).toEqual({
+      color: 0xff0000,
+      text: 'DMG',
+      img: 'damage.png',
+      min: 0,
+      max: 50,
+      startingValue: 3,
+    });
+  });
+
+  it('accepts a minimal definition (no text, no img)', () => {
+    const parsed = parseCounterTypeDef(
+      { color: 0x123456, min: 0, max: 10, startingValue: 0 },
+      'test',
+    );
+    expect(parsed).toEqual({
+      color: 0x123456,
+      min: 0,
+      max: 10,
+      startingValue: 0,
+    });
+    expect(parsed.text).toBeUndefined();
+    expect(parsed.img).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => parseCounterTypeDef(null, 'ctx')).toThrow(/must be an object/);
+    expect(() => parseCounterTypeDef('string', 'ctx')).toThrow(
+      /must be an object/,
+    );
+    expect(() => parseCounterTypeDef(42, 'ctx')).toThrow(/must be an object/);
+  });
+
+  it('rejects missing color', () => {
+    expect(() =>
+      parseCounterTypeDef({ min: 0, max: 10, startingValue: 0 }, 'ctx'),
+    ).toThrow(/'color' must be a finite number/);
+  });
+
+  it('rejects non-number color', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 'red', min: 0, max: 10, startingValue: 0 },
+        'ctx',
+      ),
+    ).toThrow(/'color' must be a finite number/);
+  });
+
+  it('rejects non-finite numeric fields', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: Infinity, min: 0, max: 10, startingValue: 0 },
+        'ctx',
+      ),
+    ).toThrow(/'color' must be a finite number/);
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 0, min: 0, max: NaN, startingValue: 0 },
+        'ctx',
+      ),
+    ).toThrow(/'max' must be a finite number/);
+  });
+
+  it('rejects min > max', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 0, min: 10, max: 5, startingValue: 0 },
+        'ctx',
+      ),
+    ).toThrow(/'min' \(10\) must be <= 'max' \(5\)/);
+  });
+
+  it('accepts min === max (zero-range counter)', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 0, min: 5, max: 5, startingValue: 5 },
+        'ctx',
+      ),
+    ).not.toThrow();
+  });
+
+  it('does NOT clamp startingValue to [min, max]', () => {
+    // Per design note in parseCounterTypeDef: startingValue may legitimately
+    // sit outside [min, max] (template re-use across modes). Validation only
+    // checks that it's a finite number.
+    const parsed = parseCounterTypeDef(
+      { color: 0, min: 0, max: 10, startingValue: 99 },
+      'ctx',
+    );
+    expect(parsed.startingValue).toBe(99);
+  });
+
+  it('rejects non-string text when present', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 0, min: 0, max: 10, startingValue: 0, text: 42 },
+        'ctx',
+      ),
+    ).toThrow(/'text' must be a string/);
+  });
+
+  it('rejects non-string img when present', () => {
+    expect(() =>
+      parseCounterTypeDef(
+        { color: 0, min: 0, max: 10, startingValue: 0, img: false },
+        'ctx',
+      ),
+    ).toThrow(/'img' must be a string/);
+  });
+
+  it('includes the supplied context in error messages', () => {
+    expect(() => parseCounterTypeDef(null, 'plugin foo entry bar')).toThrow(
+      /^plugin foo entry bar:/,
+    );
+  });
+});
+
+describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
+  beforeEach(() => {
+    clearLoadableEntries();
+  });
+
+  it('returns undefined when no plugin is loaded', () => {
+    expect(getCounterTypeDef('damage')).toBeUndefined();
+    expect(getAllCounterTypeDefs()).toEqual([]);
+  });
+
+  it('resolves a single counter type from a plugin manifest', () => {
+    const entry = counterEntry([
+      { id: 'damage', label: 'Damage', data: validDef },
+    ]);
+    setLoadableEntries([entry], createGameAssets());
+
+    const resolved = getCounterTypeDef('damage');
+    expect(resolved).toEqual({
+      id: 'damage',
+      label: 'Damage',
+      def: validDef,
+    });
+  });
+
+  it('returns undefined for an unknown id even when others are registered', () => {
+    const entry = counterEntry([
+      { id: 'damage', label: 'Damage', data: validDef },
+    ]);
+    setLoadableEntries([entry], createGameAssets());
+
+    expect(getCounterTypeDef('unknown')).toBeUndefined();
+  });
+
+  it('lists every declared counter type', () => {
+    const entry = counterEntry([
+      { id: 'damage', label: 'Damage', data: validDef },
+      {
+        id: 'threat',
+        label: 'Threat',
+        data: { color: 0x3498db, min: 0, max: 20, startingValue: 0 },
+      },
+    ]);
+    setLoadableEntries([entry], createGameAssets());
+
+    const list = getAllCounterTypeDefs();
+    expect(list).toHaveLength(2);
+    const byId = Object.fromEntries(list.map((r) => [r.id, r]));
+    expect(byId['damage']?.label).toBe('Damage');
+    expect(byId['damage']?.def).toEqual(validDef);
+    expect(byId['threat']?.label).toBe('Threat');
+    expect(byId['threat']?.def.color).toBe(0x3498db);
+  });
+
+  it('passes through optional text and img', () => {
+    const entry = counterEntry([
+      {
+        id: 'shield',
+        label: 'Shield',
+        data: {
+          color: 0,
+          text: 'SHD',
+          img: 'shield.png',
+          min: 0,
+          max: 10,
+          startingValue: 0,
+        },
+      },
+    ]);
+    setLoadableEntries([entry], createGameAssets());
+
+    const resolved = getCounterTypeDef('shield');
+    expect(resolved?.def.text).toBe('SHD');
+    expect(resolved?.def.img).toBe('shield.png');
+  });
+
+  describe('multiple-loadable-entry merging', () => {
+    it('flattens counter types across multiple `type: counter` entries', () => {
+      // Plugins may declare more than one `counter` loadable (e.g. grouped
+      // by theme); the resolver flattens them. Matches the `scenario`
+      // precedent in getLoadablesOfType tests.
+      const entryA = counterEntry([
+        { id: 'damage', label: 'Damage', data: validDef },
+      ]);
+      const entryB = counterEntry([
+        {
+          id: 'threat',
+          label: 'Threat',
+          data: { color: 0x3498db, min: 0, max: 20, startingValue: 0 },
+        },
+      ]);
+      setLoadableEntries([entryA, entryB], createGameAssets());
+
+      const ids = getAllCounterTypeDefs()
+        .map((r) => r.id)
+        .sort();
+      expect(ids).toEqual(['damage', 'threat']);
+    });
+  });
+
+  describe('malformed declarations', () => {
+    it('drops malformed entries from getAllCounterTypeDefs with a warning', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const entry = counterEntry([
+        { id: 'valid', label: 'Valid', data: validDef },
+        { id: 'bad', label: 'Bad', data: { color: 'red' } },
+      ]);
+      setLoadableEntries([entry], createGameAssets());
+
+      const list = getAllCounterTypeDefs();
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe('valid');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("dropping malformed counter type 'bad'"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('keeps the first declaration when ids collide within the same plugin load', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const entry = counterEntry([
+        { id: 'damage', label: 'Damage A', data: validDef },
+        {
+          id: 'damage',
+          label: 'Damage B',
+          data: { ...validDef, color: 0x000000 },
+        },
+      ]);
+      setLoadableEntries([entry], createGameAssets());
+
+      const list = getAllCounterTypeDefs();
+      expect(list).toHaveLength(1);
+      expect(list[0].label).toBe('Damage A');
+      expect(list[0].def.color).toBe(validDef.color);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("duplicate counter type id 'damage'"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('getCounterTypeDef THROWS for a malformed entry with the matching id', () => {
+      // Distinct from getAllCounterTypeDefs (which drops + warns): a direct
+      // point lookup with a known id but malformed data is a hard error at
+      // spawn time — callers should not silently fall back.
+      const entry = counterEntry([
+        { id: 'bad', label: 'Bad', data: { color: 'red' } },
+      ]);
+      setLoadableEntries([entry], createGameAssets());
+
+      expect(() => getCounterTypeDef('bad')).toThrow(
+        /'color' must be a finite number/,
+      );
+    });
+  });
+
+  describe('explicit entries argument (no global registry mutation)', () => {
+    it('reads from the supplied entries array, ignoring registry state', () => {
+      // Manifest-level callers (e.g. pluginLoader pre-population) may pass
+      // entries directly without first installing them in the global
+      // registry. Verify the resolver supports that path.
+      const entries: LoadableEntry[] = [
+        counterEntry([{ id: 'explicit', label: 'Explicit', data: validDef }]),
+      ];
+
+      // Global registry is empty
+      expect(getCounterTypeDef('explicit')).toBeUndefined();
+
+      // Direct entries lookup finds it.
+      expect(getCounterTypeDef('explicit', entries)?.id).toBe('explicit');
+      expect(getAllCounterTypeDefs(entries)).toHaveLength(1);
+    });
+  });
+});

--- a/app/src/content/counterRegistry.test.ts
+++ b/app/src/content/counterRegistry.test.ts
@@ -30,7 +30,7 @@ function createGameAssets(overrides: Partial<GameAssets> = {}): GameAssets {
 }
 
 function counterEntry(
-  items: Array<{ id: string; label: string; data: unknown }>,
+  items: Array<{ typeId: string; label: string; data: unknown }>,
 ): LoadableEntry<unknown> {
   return {
     type: COUNTER_LOADABLE_TYPE,
@@ -190,13 +190,13 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
 
   it('resolves a single counter type from a plugin manifest', () => {
     const entry = counterEntry([
-      { id: 'damage', label: 'Damage', data: validDef },
+      { typeId: 'damage', label: 'Damage', data: validDef },
     ]);
     setLoadableEntries([entry], createGameAssets());
 
     const resolved = getCounterTypeDef('damage');
     expect(resolved).toEqual({
-      id: 'damage',
+      typeId: 'damage',
       label: 'Damage',
       def: validDef,
     });
@@ -204,7 +204,7 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
 
   it('returns undefined for an unknown id even when others are registered', () => {
     const entry = counterEntry([
-      { id: 'damage', label: 'Damage', data: validDef },
+      { typeId: 'damage', label: 'Damage', data: validDef },
     ]);
     setLoadableEntries([entry], createGameAssets());
 
@@ -213,9 +213,9 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
 
   it('lists every declared counter type', () => {
     const entry = counterEntry([
-      { id: 'damage', label: 'Damage', data: validDef },
+      { typeId: 'damage', label: 'Damage', data: validDef },
       {
-        id: 'threat',
+        typeId: 'threat',
         label: 'Threat',
         data: { color: 0x3498db, min: 0, max: 20, startingValue: 0 },
       },
@@ -224,7 +224,7 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
 
     const list = getAllCounterTypeDefs();
     expect(list).toHaveLength(2);
-    const byId = Object.fromEntries(list.map((r) => [r.id, r]));
+    const byId = Object.fromEntries(list.map((r) => [r.typeId, r]));
     expect(byId['damage']?.label).toBe('Damage');
     expect(byId['damage']?.def).toEqual(validDef);
     expect(byId['threat']?.label).toBe('Threat');
@@ -234,7 +234,7 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
   it('passes through optional text and img', () => {
     const entry = counterEntry([
       {
-        id: 'shield',
+        typeId: 'shield',
         label: 'Shield',
         data: {
           color: 0,
@@ -259,11 +259,11 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       // by theme); the resolver flattens them. Matches the `scenario`
       // precedent in getLoadablesOfType tests.
       const entryA = counterEntry([
-        { id: 'damage', label: 'Damage', data: validDef },
+        { typeId: 'damage', label: 'Damage', data: validDef },
       ]);
       const entryB = counterEntry([
         {
-          id: 'threat',
+          typeId: 'threat',
           label: 'Threat',
           data: { color: 0x3498db, min: 0, max: 20, startingValue: 0 },
         },
@@ -271,7 +271,7 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       setLoadableEntries([entryA, entryB], createGameAssets());
 
       const ids = getAllCounterTypeDefs()
-        .map((r) => r.id)
+        .map((r) => r.typeId)
         .sort();
       expect(ids).toEqual(['damage', 'threat']);
     });
@@ -282,14 +282,14 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const entry = counterEntry([
-        { id: 'valid', label: 'Valid', data: validDef },
-        { id: 'bad', label: 'Bad', data: { color: 'red' } },
+        { typeId: 'valid', label: 'Valid', data: validDef },
+        { typeId: 'bad', label: 'Bad', data: { color: 'red' } },
       ]);
       setLoadableEntries([entry], createGameAssets());
 
       const list = getAllCounterTypeDefs();
       expect(list).toHaveLength(1);
-      expect(list[0].id).toBe('valid');
+      expect(list[0].typeId).toBe('valid');
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("dropping malformed counter type 'bad'"),
       );
@@ -301,9 +301,9 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       const entry = counterEntry([
-        { id: 'damage', label: 'Damage A', data: validDef },
+        { typeId: 'damage', label: 'Damage A', data: validDef },
         {
-          id: 'damage',
+          typeId: 'damage',
           label: 'Damage B',
           data: { ...validDef, color: 0x000000 },
         },
@@ -326,7 +326,7 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       // point lookup with a known id but malformed data is a hard error at
       // spawn time — callers should not silently fall back.
       const entry = counterEntry([
-        { id: 'bad', label: 'Bad', data: { color: 'red' } },
+        { typeId: 'bad', label: 'Bad', data: { color: 'red' } },
       ]);
       setLoadableEntries([entry], createGameAssets());
 
@@ -342,14 +342,16 @@ describe('getCounterTypeDef / getAllCounterTypeDefs', () => {
       // entries directly without first installing them in the global
       // registry. Verify the resolver supports that path.
       const entries: LoadableEntry[] = [
-        counterEntry([{ id: 'explicit', label: 'Explicit', data: validDef }]),
+        counterEntry([
+          { typeId: 'explicit', label: 'Explicit', data: validDef },
+        ]),
       ];
 
       // Global registry is empty
       expect(getCounterTypeDef('explicit')).toBeUndefined();
 
       // Direct entries lookup finds it.
-      expect(getCounterTypeDef('explicit', entries)?.id).toBe('explicit');
+      expect(getCounterTypeDef('explicit', entries)?.typeId).toBe('explicit');
       expect(getAllCounterTypeDefs(entries)).toHaveLength(1);
     });
   });

--- a/app/src/content/counterRegistry.ts
+++ b/app/src/content/counterRegistry.ts
@@ -5,8 +5,8 @@
  * Plugins declare counter type definitions through the generic loadables[]
  * system using `type: 'counter'` entries with static sources. Each
  * LoadableStaticItem carries:
- *   - `id`        — the counter type id (used by the resolver / typeId
- *                   provenance on materialized instances)
+ *   - `typeId`    — the counter type id (used by the resolver and copied as
+ *                   `typeId` provenance on materialized instances)
  *   - `label`     — picker display label
  *   - `data`      — a `CounterTypeDef` payload: `{color, text?, img?, min,
  *                   max, startingValue}` (template-only — instance fields
@@ -18,9 +18,9 @@
  *                                 plugin-manifest boundary; throws a
  *                                 descriptive Error on malformed input.
  *   - `getAllCounterTypeDefs`   — list every plugin-declared counter type as
- *                                 resolved `(id, label, data)` tuples.
- *   - `getCounterTypeDef`       — point lookup by id; `undefined` when the
- *                                 type isn't declared.
+ *                                 resolved `(typeId, label, data)` tuples.
+ *   - `getCounterTypeDef`       — point lookup by typeId; `undefined` when
+ *                                 the type isn't declared.
  *
  * Validation lives at the boundary (plugin manifest → host) because the
  * loadable `data` payload is typed as `unknown` at the shared-schema layer
@@ -43,8 +43,8 @@ import { getLoadableEntries, getStaticItems } from './loadablesRegistry';
  * alongside the template fields in a single object.
  */
 export interface ResolvedCounterTypeDef {
-  /** Counter type id (matches `LoadableStaticItem.id`). */
-  id: string;
+  /** Counter type id (matches `LoadableStaticItem.typeId`). */
+  typeId: string;
   /** Display label (matches `LoadableStaticItem.label`). */
   label: string;
   /** Template fields (color, optional text/img, min, max, startingValue). */
@@ -169,19 +169,19 @@ export function getAllCounterTypeDefs(
  * "type not declared").
  */
 export function getCounterTypeDef(
-  id: string,
+  typeId: string,
   entries?: LoadableEntry[],
 ): ResolvedCounterTypeDef | undefined {
   const source = entries ?? getLoadableEntries();
   const items = getStaticItems<unknown>(source, COUNTER_LOADABLE_TYPE);
 
   for (const item of items) {
-    if (item.id !== id) continue;
+    if (item.typeId !== typeId) continue;
     const def = parseCounterTypeDef(
       item.data,
-      `[counterRegistry] counter type '${item.id}'`,
+      `[counterRegistry] counter type '${item.typeId}'`,
     );
-    return { id: item.id, label: item.label, def };
+    return { typeId: item.typeId, label: item.label, def };
   }
   return undefined;
 }
@@ -206,23 +206,23 @@ function resolveItems(
   const seen = new Set<string>();
 
   for (const item of items) {
-    if (seen.has(item.id)) {
+    if (seen.has(item.typeId)) {
       console.warn(
-        `[counterRegistry] duplicate counter type id '${item.id}' — keeping first declaration`,
+        `[counterRegistry] duplicate counter type id '${item.typeId}' — keeping first declaration`,
       );
       continue;
     }
     try {
       const def = parseCounterTypeDef(
         item.data,
-        `[counterRegistry] counter type '${item.id}'`,
+        `[counterRegistry] counter type '${item.typeId}'`,
       );
-      resolved.push({ id: item.id, label: item.label, def });
-      seen.add(item.id);
+      resolved.push({ typeId: item.typeId, label: item.label, def });
+      seen.add(item.typeId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(
-        `[counterRegistry] dropping malformed counter type '${item.id}': ${message}`,
+        `[counterRegistry] dropping malformed counter type '${item.typeId}': ${message}`,
       );
     }
   }

--- a/app/src/content/counterRegistry.ts
+++ b/app/src/content/counterRegistry.ts
@@ -1,0 +1,230 @@
+/**
+ * Counter-type registry: resolver + validator over plugin-declared `counters`
+ * loadable entries.
+ *
+ * Plugins declare counter type definitions through the generic loadables[]
+ * system using `type: 'counter'` entries with static sources. Each
+ * LoadableStaticItem carries:
+ *   - `id`        — the counter type id (used by the resolver / typeId
+ *                   provenance on materialized instances)
+ *   - `label`     — picker display label
+ *   - `data`      — a `CounterTypeDef` payload: `{color, text?, img?, min,
+ *                   max, startingValue}` (template-only — instance fields
+ *                   like `typeId` and `currentValue` are assigned at spawn
+ *                   time, NOT in plugin declarations)
+ *
+ * This module is the thin per-type layer on top of `loadablesRegistry`:
+ *   - `parseCounterTypeDef`     — validate a raw payload at the
+ *                                 plugin-manifest boundary; throws a
+ *                                 descriptive Error on malformed input.
+ *   - `getAllCounterTypeDefs`   — list every plugin-declared counter type as
+ *                                 resolved `(id, label, data)` tuples.
+ *   - `getCounterTypeDef`       — point lookup by id; `undefined` when the
+ *                                 type isn't declared.
+ *
+ * Validation lives at the boundary (plugin manifest → host) because the
+ * loadable `data` payload is typed as `unknown` at the shared-schema layer
+ * (see content-types.ts). `typeof` checks are acceptable here per CLAUDE.md
+ * — this is a system boundary, not internal type validation.
+ */
+
+import {
+  COUNTER_LOADABLE_TYPE,
+  type CounterTypeDef,
+  type LoadableEntry,
+  type LoadableStaticItem,
+} from '@cardtable2/shared';
+import { getLoadableEntries, getStaticItems } from './loadablesRegistry';
+
+/**
+ * Resolved counter type definition: the parsed `CounterTypeDef` payload
+ * paired with the loadable's id and label. Returned by `getCounterTypeDef`
+ * and `getAllCounterTypeDefs` so callers get the type id + display label
+ * alongside the template fields in a single object.
+ */
+export interface ResolvedCounterTypeDef {
+  /** Counter type id (matches `LoadableStaticItem.id`). */
+  id: string;
+  /** Display label (matches `LoadableStaticItem.label`). */
+  label: string;
+  /** Template fields (color, optional text/img, min, max, startingValue). */
+  def: CounterTypeDef;
+}
+
+/**
+ * Validate a raw `LoadableStaticItem.data` value as a `CounterTypeDef`.
+ *
+ * Required fields: `color`, `min`, `max`, `startingValue` (all numbers).
+ * Optional fields: `text` (string), `img` (string). Numeric fields must be
+ * finite. `startingValue` is NOT clamped to `[min, max]` here — that's an
+ * instance-time concern; type defs may legitimately ship a startingValue
+ * outside the [min, max] band (e.g. a template re-used in multiple modes).
+ *
+ * The `context` string is prepended to error messages so the loader can
+ * report which plugin manifest entry failed validation.
+ *
+ * @throws Error with a descriptive message when validation fails.
+ */
+export function parseCounterTypeDef(
+  data: unknown,
+  context: string,
+): CounterTypeDef {
+  if (typeof data !== 'object' || data === null) {
+    throw new Error(
+      `${context}: counter type def must be an object, got ${data === null ? 'null' : typeof data}`,
+    );
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  const color = obj.color;
+  if (typeof color !== 'number' || !Number.isFinite(color)) {
+    throw new Error(
+      `${context}: counter type def 'color' must be a finite number (RGB int), got ${describe(color)}`,
+    );
+  }
+
+  const min = obj.min;
+  if (typeof min !== 'number' || !Number.isFinite(min)) {
+    throw new Error(
+      `${context}: counter type def 'min' must be a finite number, got ${describe(min)}`,
+    );
+  }
+
+  const max = obj.max;
+  if (typeof max !== 'number' || !Number.isFinite(max)) {
+    throw new Error(
+      `${context}: counter type def 'max' must be a finite number, got ${describe(max)}`,
+    );
+  }
+
+  if (min > max) {
+    throw new Error(
+      `${context}: counter type def 'min' (${min}) must be <= 'max' (${max})`,
+    );
+  }
+
+  const startingValue = obj.startingValue;
+  if (typeof startingValue !== 'number' || !Number.isFinite(startingValue)) {
+    throw new Error(
+      `${context}: counter type def 'startingValue' must be a finite number, got ${describe(startingValue)}`,
+    );
+  }
+
+  const text = obj.text;
+  if (text !== undefined && typeof text !== 'string') {
+    throw new Error(
+      `${context}: counter type def 'text' must be a string when present, got ${describe(text)}`,
+    );
+  }
+
+  const img = obj.img;
+  if (img !== undefined && typeof img !== 'string') {
+    throw new Error(
+      `${context}: counter type def 'img' must be a string when present, got ${describe(img)}`,
+    );
+  }
+
+  const result: CounterTypeDef = {
+    color,
+    min,
+    max,
+    startingValue,
+  };
+  if (text !== undefined) result.text = text;
+  if (img !== undefined) result.img = img;
+  return result;
+}
+
+/**
+ * Return every plugin-declared counter type as a resolved
+ * `(id, label, def)` tuple.
+ *
+ * Reads from the host loadables registry — callers must have already
+ * loaded a plugin (`setLoadableEntries`) for this to return anything.
+ *
+ * Malformed counter entries are dropped with a `console.warn` rather than
+ * aborting the whole list — one bad declaration shouldn't hide every other
+ * counter type from the picker / spawn flow.
+ *
+ * Within a single plugin, the first declaration of a given id wins; later
+ * declarations of the same id log a warning and are skipped. Cross-plugin
+ * collisions surface here too if/when multi-plugin sessions exist (the
+ * loadables registry currently holds one plugin's entries at a time).
+ */
+export function getAllCounterTypeDefs(
+  entries?: LoadableEntry[],
+): ResolvedCounterTypeDef[] {
+  const source = entries ?? getLoadableEntries();
+  const items = getStaticItems<unknown>(source, COUNTER_LOADABLE_TYPE);
+  return resolveItems(items);
+}
+
+/**
+ * Point lookup for a single counter type def by id.
+ *
+ * Returns `undefined` when no entry with the requested id is declared.
+ * A malformed entry with the matching id throws (callers should treat
+ * malformed declarations as a hard error at spawn time, distinct from
+ * "type not declared").
+ */
+export function getCounterTypeDef(
+  id: string,
+  entries?: LoadableEntry[],
+): ResolvedCounterTypeDef | undefined {
+  const source = entries ?? getLoadableEntries();
+  const items = getStaticItems<unknown>(source, COUNTER_LOADABLE_TYPE);
+
+  for (const item of items) {
+    if (item.id !== id) continue;
+    const def = parseCounterTypeDef(
+      item.data,
+      `[counterRegistry] counter type '${item.id}'`,
+    );
+    return { id: item.id, label: item.label, def };
+  }
+  return undefined;
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function describe(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return Number.isNaN(value) ? 'NaN' : `${value}`;
+  }
+  return typeof value;
+}
+
+function resolveItems(
+  items: LoadableStaticItem<unknown>[],
+): ResolvedCounterTypeDef[] {
+  const resolved: ResolvedCounterTypeDef[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    if (seen.has(item.id)) {
+      console.warn(
+        `[counterRegistry] duplicate counter type id '${item.id}' — keeping first declaration`,
+      );
+      continue;
+    }
+    try {
+      const def = parseCounterTypeDef(
+        item.data,
+        `[counterRegistry] counter type '${item.id}'`,
+      );
+      resolved.push({ id: item.id, label: item.label, def });
+      seen.add(item.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[counterRegistry] dropping malformed counter type '${item.id}': ${message}`,
+      );
+    }
+  }
+  return resolved;
+}

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -389,6 +389,75 @@ export interface LoadableEntry<TData = unknown> {
   source: LoadableItemSource<TData>; // How items are discovered
 }
 
+/**
+ * Counter-type-definition payload carried by `loadables[]` entries with
+ * `type: 'counter'`.
+ *
+ * Each plugin-declared counter type is the *template* a Counter instance is
+ * materialized from (auto-spawn or picker). Template-only by design — the
+ * instance-time fields (`typeId`, `currentValue`) are not part of the
+ * declaration; they are assigned when a Counter object is created from the
+ * template (see ct-c7c, ct-jxl).
+ *
+ * The loadable's `LoadableStaticItem.id` doubles as the counter type id —
+ * resolvers look up a type def by item id. The static item's `label` drives
+ * the picker UI; `text` (when set) is the small display label baked into the
+ * pill render.
+ *
+ * Conventional manifest entry:
+ *
+ * ```json
+ * {
+ *   "type": "counter",
+ *   "label": "Counter",
+ *   "mode": "additive",
+ *   "source": {
+ *     "kind": "static",
+ *     "items": [
+ *       {
+ *         "id": "damage",
+ *         "label": "Damage",
+ *         "data": {
+ *           "color": 16280146,
+ *           "text": "DMG",
+ *           "min": 0,
+ *           "max": 99,
+ *           "startingValue": 0
+ *         }
+ *       }
+ *     ]
+ *   }
+ * }
+ * ```
+ *
+ * Note the distinction from the `Counter` asset-pack interface above:
+ * `Counter` (`{label, min, max, start}`) is the *legacy* counter catalog
+ * entry used by `ComponentSetCounter.ref`. `CounterTypeDef` is the
+ * loadables-system payload for the typed-counter spawn flow.
+ */
+export interface CounterTypeDef {
+  /** RGB number for the pill body (e.g. `0xf39c12`). */
+  color: number;
+  /** Optional short display label baked into the pill (e.g. `"DMG"`). */
+  text?: string;
+  /** Optional icon image URL for icon-backed counters. */
+  img?: string;
+  /** Lower clamp on `currentValue`. */
+  min: number;
+  /** Upper clamp on `currentValue`. */
+  max: number;
+  /** Initial `currentValue` when an instance is materialized. */
+  startingValue: number;
+}
+
+/**
+ * Plugin-declared counter-loadable type string. Hard-coded here (rather than
+ * left as an arbitrary plugin-defined string) because the host's typed-counter
+ * spawn / picker / resolver consumers all key off this same constant; using a
+ * shared literal prevents drift across consumers.
+ */
+export const COUNTER_LOADABLE_TYPE = 'counter';
+
 // ============================================================================
 // Worker Communication Types
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `counter` as a new loadable type in `shared/src/content-types.ts`, mirroring the `card` / `component-set` precedent. Plugin manifests can now declare counter type definitions with template-only fields: `color, text?, img?, min, max, startingValue`.
- New `app/src/content/counterRegistry.ts` provides `parseCounterTypeDef` (boundary validation with descriptive errors), `getAllCounterTypeDefs` (list resolver; drops malformed entries with `console.warn`), and `getCounterTypeDef` (point lookup; throws on malformed matched id).
- Two example types (`damage`, `threat`) added to `app/public/plugins/testgame/index.json` so the runtime path is exercised.

## Schema choices worth a look
- `id` lives on `LoadableStaticItem.id`, not duplicated inside the `data` payload (`CounterTypeDef` stays template-only). Matches the `card` loadable's `{id, data: {code: id}}` shape and keeps the static-item structure honest. Resolver returns `ResolvedCounterTypeDef {id, label, def}` so callers still get one object.
- Asymmetric error handling: `getCounterTypeDef` **throws** on malformed matched id; `getAllCounterTypeDefs` **drops + warns**. Rationale: the list path shouldn't hide every other type behind one bad declaration; the point-lookup path should fail loud at spawn time rather than silently materialize a generic counter.
- `startingValue` is **not** clamped to `[min, max]` at parse — clamping is an instance-time concern, and templates may legitimately re-use across modes.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (1253 passing; 22 new in `counterRegistry.test.ts` covering parse acceptance/rejection, registry lookup, multi-entry flattening, duplicate-id, malformed-drop, explicit-entries arg)
- [x] No suppressions; `typeof` only at the parse boundary; no inline `import()` casts

🤖 Generated with [Claude Code](https://claude.com/claude-code)