### PR TITLE
feat(counters): pill render with value, +/-, label (ct-yxh)

### DIFF
--- a/app/src/renderer/handlers/coordinates.ts
+++ b/app/src/renderer/handlers/coordinates.ts
@@ -10,7 +10,7 @@ import type { RendererContext } from '../RendererContext';
 import { STACK_WIDTH, STACK_HEIGHT } from '../objects/stack/constants';
 import { getTokenSize } from '../objects/token/utils';
 import { getMatSize } from '../objects/mat/utils';
-import { getCounterSize } from '../objects/counter/utils';
+import { getCounterDimensions } from '../objects/counter/utils';
 
 /**
  * Handle request-screen-coords message
@@ -74,9 +74,9 @@ export function handleRequestScreenCoords(
           width = radius * 2;
           height = radius * 2;
         } else if (obj._kind === ObjectKind.Counter) {
-          const radius = (getCounterSize(obj) * cameraScale) / dpr;
-          width = radius * 2;
-          height = radius * 2;
+          const dims = getCounterDimensions(obj);
+          width = (dims.width * cameraScale) / dpr;
+          height = (dims.height * cameraScale) / dpr;
         }
 
         screenCoords.push({

--- a/app/src/renderer/managers/VisualManager.ts
+++ b/app/src/renderer/managers/VisualManager.ts
@@ -9,7 +9,7 @@ import type { TextureLoader } from '../services/TextureLoader';
 import { STACK_WIDTH, STACK_HEIGHT } from '../objects/stack/constants';
 import { getTokenSize } from '../objects/token/utils';
 import { getMatSize } from '../objects/mat/utils';
-import { getCounterSize } from '../objects/counter/utils';
+import { getCounterDimensions } from '../objects/counter/utils';
 import type { SceneManager } from '../SceneManager';
 import type { SelectionManager } from './SelectionManager';
 import type { HoverManager } from './HoverManager';
@@ -1031,10 +1031,9 @@ export class VisualManager {
           width = radius * 2;
           height = radius * 2;
         } else if (obj._kind === ObjectKind.Counter) {
-          const radius =
-            (getCounterSize(obj) * this.cameraScale) / devicePixelRatio;
-          width = radius * 2;
-          height = radius * 2;
+          const dims = getCounterDimensions(obj);
+          width = (dims.width * this.cameraScale) / devicePixelRatio;
+          height = (dims.height * this.cameraScale) / devicePixelRatio;
         }
 
         screenCoords.push({

--- a/app/src/renderer/objects/counter/behaviors.test.ts
+++ b/app/src/renderer/objects/counter/behaviors.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { CounterBehaviors } from './behaviors';
+import { ObjectKind, type TableObject } from '@cardtable2/shared';
+import type { RenderContext } from '../types';
+import { Text, Container, type TextOptions } from 'pixi.js';
+import {
+  COUNTER_PILL_BORDER_RADIUS,
+  COUNTER_PILL_HEIGHT,
+  COUNTER_PILL_WIDTH,
+} from './constants';
+import { getCounterDimensions } from './utils';
+
+// Helper to create test counter objects with all required CounterMeta fields.
+function createTestCounter(
+  overrides?: Partial<TableObject> & {
+    meta?: Record<string, unknown>;
+  },
+): TableObject {
+  const { meta, ...rest } = overrides ?? {};
+  return {
+    _kind: ObjectKind.Counter,
+    _pos: { x: 0, y: 0, r: 0 },
+    _containerId: null,
+    _sortKey: '0',
+    _locked: false,
+    _selectedBy: null,
+    _meta: {
+      type: 'generic',
+      typeId: 'generic',
+      color: 0xf39c12,
+      min: 0,
+      max: 99,
+      startingValue: 0,
+      currentValue: 0,
+      ...(meta ?? {}),
+    },
+    ...rest,
+  };
+}
+
+describe('Counter Behaviors - Pill Geometry', () => {
+  describe('getBounds', () => {
+    it('returns a rectangle matching pill width/height centered on _pos', () => {
+      const counter = createTestCounter({
+        _pos: { x: 100, y: 50, r: 0 },
+      });
+
+      const bounds = CounterBehaviors.getBounds(counter);
+
+      expect(bounds.minX).toBe(100 - COUNTER_PILL_WIDTH / 2);
+      expect(bounds.maxX).toBe(100 + COUNTER_PILL_WIDTH / 2);
+      expect(bounds.minY).toBe(50 - COUNTER_PILL_HEIGHT / 2);
+      expect(bounds.maxY).toBe(50 + COUNTER_PILL_HEIGHT / 2);
+    });
+
+    it('returns bounds wider than tall (horizontal pill)', () => {
+      const counter = createTestCounter();
+      const bounds = CounterBehaviors.getBounds(counter);
+
+      const width = bounds.maxX - bounds.minX;
+      const height = bounds.maxY - bounds.minY;
+      expect(width).toBeGreaterThan(height);
+    });
+  });
+
+  describe('getShadowConfig', () => {
+    it('returns rect shape with the pill dimensions and matching border radius', () => {
+      const counter = createTestCounter();
+
+      const shadow = CounterBehaviors.getShadowConfig(counter);
+
+      expect(shadow.shape).toBe('rect');
+      expect(shadow.width).toBe(COUNTER_PILL_WIDTH);
+      expect(shadow.height).toBe(COUNTER_PILL_HEIGHT);
+      expect(shadow.borderRadius).toBe(COUNTER_PILL_BORDER_RADIUS);
+    });
+  });
+
+  describe('capabilities', () => {
+    it('disallows flip/rotate/stack but allows lock', () => {
+      expect(CounterBehaviors.capabilities).toEqual({
+        canFlip: false,
+        canRotate: false,
+        canStack: false,
+        canUnstack: false,
+        canLock: true,
+      });
+    });
+  });
+});
+
+describe('getCounterDimensions', () => {
+  it('returns the pill width/height constants', () => {
+    const counter = createTestCounter();
+    expect(getCounterDimensions(counter)).toEqual({
+      width: COUNTER_PILL_WIDTH,
+      height: COUNTER_PILL_HEIGHT,
+    });
+  });
+});
+
+describe('Counter Behaviors - Rendering', () => {
+  let mockContext: RenderContext;
+  let mockCreateText: Mock<(options: TextOptions) => Text>;
+  let mockCreateKindLabel: Mock<(text: string) => Text>;
+  let mockScaleStrokeWidth: Mock<(baseWidth: number) => number>;
+
+  beforeEach(() => {
+    mockCreateText = vi.fn((options: TextOptions) => {
+      const text = new Text(options);
+      text.resolution = 6; // Simulated zoom-aware resolution
+      return text;
+    });
+
+    mockCreateKindLabel = vi.fn((textString: string) => {
+      const text = new Text({
+        text: textString,
+        style: {
+          fontSize: 24,
+          fill: 0xffffff,
+          stroke: { color: 0x000000, width: 2 },
+        },
+      });
+      text.anchor.set(0.5);
+      return text;
+    });
+
+    mockScaleStrokeWidth = vi.fn((baseWidth: number) => baseWidth);
+
+    mockContext = {
+      isSelected: false,
+      isHovered: false,
+      isDragging: false,
+      dragActionPreview: null,
+      isStackTarget: false,
+      isAttachTarget: false,
+      cameraScale: 1.0,
+      createText: mockCreateText,
+      createKindLabel: mockCreateKindLabel,
+      scaleStrokeWidth: mockScaleStrokeWidth,
+    } as RenderContext;
+  });
+
+  it('returns a Container', () => {
+    const counter = createTestCounter();
+    const container = CounterBehaviors.render(counter, mockContext);
+    expect(container).toBeInstanceOf(Container);
+  });
+
+  it('renders currentValue as text', () => {
+    const counter = createTestCounter({
+      meta: { currentValue: 7 },
+    });
+
+    CounterBehaviors.render(counter, mockContext);
+
+    expect(mockCreateText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: '7' }),
+    );
+  });
+
+  it('renders minus and plus glyphs as side-zone affordances', () => {
+    const counter = createTestCounter();
+
+    CounterBehaviors.render(counter, mockContext);
+
+    // Unicode MINUS SIGN (U+2212) is used for visual balance vs ASCII '-'.
+    const glyphCalls = mockCreateText.mock.calls.map((call) => call[0].text);
+    expect(glyphCalls).toContain('−');
+    expect(glyphCalls).toContain('+');
+  });
+
+  it('renders the optional label when meta.text is set', () => {
+    const counter = createTestCounter({
+      meta: { text: 'HP' },
+    });
+
+    CounterBehaviors.render(counter, mockContext);
+
+    const labelCall = mockCreateText.mock.calls.find(
+      (call) => call[0].text === 'HP',
+    );
+    expect(labelCall).toBeDefined();
+  });
+
+  it('does not render the label when meta.text is undefined', () => {
+    const counter = createTestCounter(); // no `text`
+
+    CounterBehaviors.render(counter, mockContext);
+
+    const textsRendered = mockCreateText.mock.calls.map((call) => call[0].text);
+    // Only +, −, currentValue ("0") should appear — no label.
+    expect(textsRendered).not.toContain('HP');
+    expect(textsRendered.filter((t) => t === '0').length).toBe(1);
+  });
+
+  it('does not render the label when meta.text is an empty string', () => {
+    const counter = createTestCounter({
+      meta: { text: '' },
+    });
+
+    CounterBehaviors.render(counter, mockContext);
+
+    // We can't easily detect an empty-string call, but at minimum it
+    // shouldn't add a fourth Text on top of value + minus + plus.
+    expect(mockCreateText).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders the value text in the bold/white/dark-stroke stack-badge style', () => {
+    const counter = createTestCounter({ meta: { currentValue: 3 } });
+
+    CounterBehaviors.render(counter, mockContext);
+
+    const valueCall = mockCreateText.mock.calls.find(
+      (call) => call[0].text === '3',
+    );
+    expect(valueCall).toBeDefined();
+    // `style` on TextOptions is `Partial<TextStyleOptions>`; cast to a loose
+    // record for property-level assertion (style-equality on the pixi style
+    // record itself is brittle).
+    const style = valueCall![0].style as Record<string, unknown>;
+    expect(style.fontWeight).toBe('bold');
+    expect(style.fill).toBe(0xffffff);
+    // Stroke is an object — we just assert it's present.
+    expect(style.stroke).toBeDefined();
+  });
+
+  it('skips +/-/value/label rendering in minimal mode', () => {
+    const counter = createTestCounter({
+      meta: { text: 'HP', currentValue: 5 },
+    });
+
+    const minimalCtx = { ...mockContext, minimal: true };
+    const container = CounterBehaviors.render(counter, minimalCtx);
+
+    expect(container).toBeInstanceOf(Container);
+    // In minimal mode only the pill body is rendered — no text calls.
+    expect(mockCreateText).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/renderer/objects/counter/behaviors.ts
+++ b/app/src/renderer/objects/counter/behaviors.ts
@@ -4,55 +4,157 @@ import type { ObjectBehaviors, RenderContext, ShadowConfig } from '../types';
 import {
   COUNTER_BORDER_COLOR_NORMAL,
   COUNTER_BORDER_COLOR_SELECTED,
+  COUNTER_LABEL_ALPHA,
+  COUNTER_LABEL_FONT_SIZE,
+  COUNTER_LABEL_TEXT_COLOR,
+  COUNTER_PILL_BORDER_RADIUS,
+  COUNTER_VALUE_FONT_SIZE,
+  COUNTER_VALUE_STROKE_COLOR,
+  COUNTER_VALUE_STROKE_WIDTH,
+  COUNTER_VALUE_TEXT_COLOR,
+  COUNTER_ZONE_GLYPH_ALPHA,
+  COUNTER_ZONE_GLYPH_COLOR,
+  COUNTER_ZONE_GLYPH_FONT_SIZE,
 } from './constants';
-import { getCounterColor, getCounterSize } from './utils';
+import {
+  getCounterColor,
+  getCounterCurrentValue,
+  getCounterDimensions,
+  getCounterText,
+} from './utils';
 
+/**
+ * Counter render (ct-yxh): horizontal rounded-rectangle pill with three
+ * conceptual zones — left third minus, center third value, right third plus.
+ *
+ * The +/- glyphs are rendered at moderate opacity as visual affordances
+ * only; event wiring (clicks/taps to mutate `currentValue`) is the next
+ * bead (ct-d2p).
+ *
+ * Coordinate system: visuals are centered at the object's `_pos`. World
+ * coordinates inside this render run from `-WIDTH/2 .. +WIDTH/2` on x and
+ * `-HEIGHT/2 .. +HEIGHT/2` on y. Zone centers fall at `-WIDTH/3`, `0`,
+ * `+WIDTH/3`.
+ */
 export const CounterBehaviors: ObjectBehaviors = {
   render(obj: TableObject, ctx: RenderContext): Container {
     const container = new Container();
-    const graphic = new Graphics();
+    const { width, height } = getCounterDimensions(obj);
     const color = getCounterColor(obj);
-    const radius = getCounterSize(obj);
 
-    graphic.circle(0, 0, radius);
-    graphic.fill(color);
-    graphic.stroke({
+    // Pill body: rounded rectangle fill + border
+    const body = new Graphics();
+    body.roundRect(
+      -width / 2,
+      -height / 2,
+      width,
+      height,
+      COUNTER_PILL_BORDER_RADIUS,
+    );
+    body.fill(color);
+    body.stroke({
       width: ctx.isSelected ? 4 : 2,
       color: ctx.isSelected
         ? COUNTER_BORDER_COLOR_SELECTED
         : COUNTER_BORDER_COLOR_NORMAL,
     });
+    container.addChild(body);
 
-    container.addChild(graphic);
+    if (ctx.minimal) {
+      return container;
+    }
 
-    // Add kind label text (unless in minimal mode)
-    if (!ctx.minimal) {
-      const text = ctx.createKindLabel(obj._kind);
-      text.anchor.set(0.5);
-      text.position.set(0, 0);
-      container.addChild(text);
+    const zoneCenterX = width / 3; // distance from center to side-zone center
+
+    // Minus glyph (left zone, decorative only — no event wiring in this bead)
+    const minusGlyph = ctx.createText({
+      text: '−', // Unicode MINUS SIGN — wider and visually balanced vs ASCII '-'
+      style: {
+        fontSize: COUNTER_ZONE_GLYPH_FONT_SIZE,
+        fill: COUNTER_ZONE_GLYPH_COLOR,
+        fontWeight: 'bold',
+      },
+    });
+    minusGlyph.label = 'counter-minus-glyph';
+    minusGlyph.anchor.set(0.5, 0.5);
+    minusGlyph.position.set(-zoneCenterX, 0);
+    minusGlyph.alpha = COUNTER_ZONE_GLYPH_ALPHA;
+    container.addChild(minusGlyph);
+
+    // Plus glyph (right zone, decorative only — no event wiring in this bead)
+    const plusGlyph = ctx.createText({
+      text: '+',
+      style: {
+        fontSize: COUNTER_ZONE_GLYPH_FONT_SIZE,
+        fill: COUNTER_ZONE_GLYPH_COLOR,
+        fontWeight: 'bold',
+      },
+    });
+    plusGlyph.label = 'counter-plus-glyph';
+    plusGlyph.anchor.set(0.5, 0.5);
+    plusGlyph.position.set(zoneCenterX, 0);
+    plusGlyph.alpha = COUNTER_ZONE_GLYPH_ALPHA;
+    container.addChild(plusGlyph);
+
+    // Current value (center zone) — mirrors the stack count badge text style:
+    // large bold white with a dark stroke for legibility against any fill.
+    const currentValue = getCounterCurrentValue(obj);
+    const valueText = ctx.createText({
+      text: currentValue.toString(),
+      style: {
+        fontSize: COUNTER_VALUE_FONT_SIZE,
+        fill: COUNTER_VALUE_TEXT_COLOR,
+        fontWeight: 'bold',
+        stroke: {
+          color: COUNTER_VALUE_STROKE_COLOR,
+          width: COUNTER_VALUE_STROKE_WIDTH,
+        },
+      },
+    });
+    valueText.label = 'counter-value';
+    valueText.anchor.set(0.5, 0.5);
+    valueText.position.set(0, 0);
+    container.addChild(valueText);
+
+    // Optional label (`text`): small, semi-opaque, top-left of center zone.
+    // Bounds of the center zone in local space: x in [-width/6, +width/6].
+    const labelText = getCounterText(obj);
+    if (labelText !== undefined && labelText.length > 0) {
+      const label = ctx.createText({
+        text: labelText,
+        style: {
+          fontSize: COUNTER_LABEL_FONT_SIZE,
+          fill: COUNTER_LABEL_TEXT_COLOR,
+          fontWeight: 'bold',
+        },
+      });
+      label.label = 'counter-label';
+      label.anchor.set(0, 0); // top-left
+      label.position.set(-width / 6 + 1, -height / 2 + 3);
+      label.alpha = COUNTER_LABEL_ALPHA;
+      container.addChild(label);
     }
 
     return container;
   },
 
   getBounds(obj: TableObject) {
-    const radius = getCounterSize(obj);
+    const { width, height } = getCounterDimensions(obj);
     return {
-      minX: obj._pos.x - radius,
-      minY: obj._pos.y - radius,
-      maxX: obj._pos.x + radius,
-      maxY: obj._pos.y + radius,
+      minX: obj._pos.x - width / 2,
+      minY: obj._pos.y - height / 2,
+      maxX: obj._pos.x + width / 2,
+      maxY: obj._pos.y + height / 2,
     };
   },
 
   getShadowConfig(obj: TableObject): ShadowConfig {
-    const radius = getCounterSize(obj);
+    const { width, height } = getCounterDimensions(obj);
     return {
-      width: radius * 2,
-      height: radius * 2,
-      shape: 'circle',
-      borderRadius: 0,
+      width,
+      height,
+      shape: 'rect',
+      borderRadius: COUNTER_PILL_BORDER_RADIUS,
     };
   },
 

--- a/app/src/renderer/objects/counter/constants.ts
+++ b/app/src/renderer/objects/counter/constants.ts
@@ -1,8 +1,17 @@
 /**
- * Default counter size (radius). Retained for legacy circle render in
- * behaviors.ts; pill geometry (ct-yxh) will own its own dimensions.
+ * Pill geometry (ct-yxh).
+ *
+ * Touch-first sizing. The pill is a horizontal rounded rectangle with three
+ * conceptual zones (minus / value / plus). Increased above the initial 60x36
+ * spec to give the +/- hit targets meaningful room at default zoom — the
+ * value zone in the center stays generous, and the side zones feel tap-
+ * friendly without requiring the user to zoom in. Event wiring for the +/-
+ * zones is the next bead (ct-d2p); these dimensions are tuned for that
+ * downstream work.
  */
-export const COUNTER_DEFAULT_SIZE = 40;
+export const COUNTER_PILL_WIDTH = 90;
+export const COUNTER_PILL_HEIGHT = 44;
+export const COUNTER_PILL_BORDER_RADIUS = COUNTER_PILL_HEIGHT / 2;
 
 /** Default counter color if not specified */
 export const COUNTER_DEFAULT_COLOR = 0xf39c12; // Orange
@@ -10,6 +19,26 @@ export const COUNTER_DEFAULT_COLOR = 0xf39c12; // Orange
 /** Border colors */
 export const COUNTER_BORDER_COLOR_NORMAL = 0x2d3436; // Dark gray
 export const COUNTER_BORDER_COLOR_SELECTED = 0xef4444; // Red
+
+/**
+ * Value text styling. Mirrors the stack count-badge text style (white fill,
+ * dark stroke, bold) so the counter value reads as the same kind of
+ * affordance as a stack's count.
+ */
+export const COUNTER_VALUE_FONT_SIZE = 22;
+export const COUNTER_VALUE_TEXT_COLOR = 0xffffff;
+export const COUNTER_VALUE_STROKE_COLOR = 0x000000;
+export const COUNTER_VALUE_STROKE_WIDTH = 3;
+
+/** +/- glyph styling (visual only in this bead; ct-d2p wires events). */
+export const COUNTER_ZONE_GLYPH_FONT_SIZE = 24;
+export const COUNTER_ZONE_GLYPH_COLOR = 0xffffff;
+export const COUNTER_ZONE_GLYPH_ALPHA = 0.55;
+
+/** Label (`text`) styling — small, semi-opaque, top-left of center zone. */
+export const COUNTER_LABEL_FONT_SIZE = 10;
+export const COUNTER_LABEL_TEXT_COLOR = 0xffffff;
+export const COUNTER_LABEL_ALPHA = 0.6;
 
 // ============================================================================
 // CounterMeta defaults (template + instance model)

--- a/app/src/renderer/objects/counter/utils.ts
+++ b/app/src/renderer/objects/counter/utils.ts
@@ -3,8 +3,9 @@ import {
   COUNTER_DEFAULT_COLOR,
   COUNTER_DEFAULT_MAX,
   COUNTER_DEFAULT_MIN,
-  COUNTER_DEFAULT_SIZE,
   COUNTER_DEFAULT_STARTING_VALUE,
+  COUNTER_PILL_HEIGHT,
+  COUNTER_PILL_WIDTH,
   COUNTER_TYPE_GENERIC,
 } from './constants';
 import type { CounterMeta } from './types';
@@ -116,13 +117,16 @@ export function getCounterCurrentValue(obj: TableObject): number {
 }
 
 /**
- * Get the size (radius) for a counter.
+ * Get the pill dimensions (width, height) for a counter in world units.
  *
- * Retained for the legacy circle render and screen-coordinate calculations
- * (coordinates.ts, VisualManager.ts, behaviors.ts) until the pill render
- * bead (ct-yxh) replaces these call sites with pill geometry. Returns the
- * default; `size` is no longer part of CounterMeta.
+ * Counters render as a horizontal rounded-rectangle pill (ct-yxh). The
+ * dimensions are fixed by `COUNTER_PILL_WIDTH` / `COUNTER_PILL_HEIGHT`;
+ * the parameter is retained for symmetry with the other object kinds and
+ * to leave room for per-instance sizing if a future bead introduces it.
  */
-export function getCounterSize(_obj: TableObject): number {
-  return COUNTER_DEFAULT_SIZE;
+export function getCounterDimensions(_obj: TableObject): {
+  width: number;
+  height: number;
+} {
+  return { width: COUNTER_PILL_WIDTH, height: COUNTER_PILL_HEIGHT };
 }


### PR DESCRIPTION
## Summary
- Replaces the placeholder circle Counter render with a rounded-rectangle pill: three zones (left `−` / center `currentValue` / right `+`), optional `text` label, color fill, rect-shaped shadow, preserved selection overlay.
- `getCounterSize` shim removed in favor of `getCounterDimensions(): {width, height}`; `coordinates.ts` and `VisualManager.ts` updated to use pill dims instead of radius.
- `+/-` glyphs render at moderate opacity — visual only in this PR. Event wiring is ct-d2p (next bead, currently blocked behind this).
- `img` rendering still deferred per the epic's scope cut.

## Final pill dimensions
**90 × 44 world units, border radius 22.** Bumped from the bead's starting 60×36 after Playwright MCP QA: the side zones felt cramped at default zoom and the value zone was tight for two-digit numbers. The bead's spec explicitly authorized "bump the size and re-verify".

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (13 new cases in `behaviors.test.ts` — pill bounds, rect shadow, capabilities, currentValue render, +/- glyphs, label conditional render, value text style, minimal mode)
- [x] Manual via Playwright MCP: pill renders correctly across zoom, color fill, centered value, +/- glyphs visible, selection border, drag, optional label

## Observation worth flagging
The agent noted 7 pre-existing console errors in Board card-preview hover (unrelated to Counters — test-card stacks without `gameAssets`). Not introduced by this PR; worth filing as a separate investigation if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)