### PR TITLE
refactor(loadables): rename LoadableStaticItem.id -> typeId (ct-by6)

### DIFF
--- a/app/public/plugins/testgame/index.json
+++ b/app/public/plugins/testgame/index.json
@@ -13,7 +13,7 @@
         "kind": "static",
         "items": [
           {
-            "id": "testgame-basic",
+            "typeId": "testgame-basic",
             "label": "Test Game - Basic Setup",
             "data": { "file": "testgame-basic.json" }
           }
@@ -28,12 +28,12 @@
         "kind": "static",
         "items": [
           {
-            "id": "encounter-basic",
+            "typeId": "encounter-basic",
             "label": "Basic Encounters",
             "data": { "cardSet": "encounter-basic" }
           },
           {
-            "id": "encounter-nemesis",
+            "typeId": "encounter-nemesis",
             "label": "Nemesis Encounters",
             "data": { "cardSet": "encounter-nemesis" }
           }

--- a/app/src/__tests__/routes/table.$id.test.tsx
+++ b/app/src/__tests__/routes/table.$id.test.tsx
@@ -280,7 +280,7 @@ describe('Table Route', () => {
           kind: 'static',
           items: [
             {
-              id: 'local-scenario-a',
+              typeId: 'local-scenario-a',
               label: 'Local Scenario A',
               data: { file: 'a.json' },
             },

--- a/app/src/components/load-picker/LoadPickerModal.fixture.ts
+++ b/app/src/components/load-picker/LoadPickerModal.fixture.ts
@@ -24,14 +24,26 @@ import type { LoadableEntry } from '@cardtable2/shared';
  * set so the search behavior is exercisable without a plugin loaded.
  */
 const FIXTURE_DERIVED_CARDS = [
-  { id: 'spider-man', label: 'Spider-Man', data: { code: 'spider-man' } },
-  { id: 'iron-man', label: 'Iron Man', data: { code: 'iron-man' } },
-  { id: 'captain-america', label: 'Captain America', data: { code: 'cap' } },
-  { id: 'black-widow', label: 'Black Widow', data: { code: 'black-widow' } },
-  { id: 'thor', label: 'Thor', data: { code: 'thor' } },
-  { id: 'hulk', label: 'Hulk', data: { code: 'hulk' } },
-  { id: 'doctor-strange', label: 'Doctor Strange', data: { code: 'strange' } },
-  { id: 'wasp', label: 'Wasp', data: { code: 'wasp' } },
+  { typeId: 'spider-man', label: 'Spider-Man', data: { code: 'spider-man' } },
+  { typeId: 'iron-man', label: 'Iron Man', data: { code: 'iron-man' } },
+  {
+    typeId: 'captain-america',
+    label: 'Captain America',
+    data: { code: 'cap' },
+  },
+  {
+    typeId: 'black-widow',
+    label: 'Black Widow',
+    data: { code: 'black-widow' },
+  },
+  { typeId: 'thor', label: 'Thor', data: { code: 'thor' } },
+  { typeId: 'hulk', label: 'Hulk', data: { code: 'hulk' } },
+  {
+    typeId: 'doctor-strange',
+    label: 'Doctor Strange',
+    data: { code: 'strange' },
+  },
+  { typeId: 'wasp', label: 'Wasp', data: { code: 'wasp' } },
 ];
 
 export const FIXTURE_LOADABLES: LoadableEntry[] = [
@@ -43,17 +55,17 @@ export const FIXTURE_LOADABLES: LoadableEntry[] = [
       kind: 'static',
       items: [
         {
-          id: 'rhino',
+          typeId: 'rhino',
           label: 'Rhino',
           data: { file: 'scenarios/rhino.json' },
         },
         {
-          id: 'klaw',
+          typeId: 'klaw',
           label: 'Klaw',
           data: { file: 'scenarios/klaw.json' },
         },
         {
-          id: 'ultron',
+          typeId: 'ultron',
           label: 'Ultron',
           data: { file: 'scenarios/ultron.json' },
         },
@@ -94,7 +106,7 @@ export const FIXTURE_LOADABLES: LoadableEntry[] = [
  * implementation for tests and the dev harness.
  */
 export function fixtureResolveDerivedItems(): Array<{
-  id: string;
+  typeId: string;
   label: string;
   data: { code: string };
 }> {

--- a/app/src/components/load-picker/LoadPickerModal.test.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.test.tsx
@@ -227,7 +227,7 @@ describe('LoadPickerModal', () => {
     const [entry, item] = onSelectItem.mock.calls[0];
     expect(entry.type).toBe('scenario');
     expect(item).toMatchObject({
-      id: 'klaw',
+      typeId: 'klaw',
       label: 'Klaw',
       data: { file: 'scenarios/klaw.json' },
     });
@@ -268,7 +268,7 @@ describe('LoadPickerModal', () => {
     // Build a 250-item derived resolver — picker should render only 200
     // until the user types.
     const big = Array.from({ length: 250 }, (_, i) => ({
-      id: `c${String(i)}`,
+      typeId: `c${String(i)}`,
       label: `Card ${String(i)}`,
       data: { code: `c${String(i)}` },
     }));
@@ -326,11 +326,11 @@ describe('LoadPickerModal', () => {
             derivedFrom: 'all-cards' as const,
             items: [
               {
-                id: 'spider-man',
+                typeId: 'spider-man',
                 label: 'Spider-Man',
                 data: { code: 'spider-man' },
               },
-              { id: 'hulk', label: 'Hulk', data: { code: 'hulk' } },
+              { typeId: 'hulk', label: 'Hulk', data: { code: 'hulk' } },
             ],
           },
         },

--- a/app/src/components/load-picker/LoadPickerModal.tsx
+++ b/app/src/components/load-picker/LoadPickerModal.tsx
@@ -25,7 +25,7 @@ const DERIVED_RENDER_CAP = 200;
  * host's loadable runtime (ct-8gf.2 / ct-8gf.5), not in the picker.
  */
 export interface LoadPickerItem {
-  id: string;
+  typeId: string;
   label: string;
   data: unknown;
 }
@@ -176,7 +176,7 @@ export function LoadPickerModal({
     const source = activeEntry.source;
     if (source.kind === 'static') {
       return source.items.map((it: LoadableStaticItem) => ({
-        id: it.id,
+        typeId: it.typeId,
         label: it.label,
         data: it.data,
       }));
@@ -194,9 +194,9 @@ export function LoadPickerModal({
       // Cap on first-paint to avoid lag for very large catalogs.
       return items.slice(0, DERIVED_RENDER_CAP);
     }
-    // Search across label and id so users can find a card by either its
+    // Search across label and typeId so users can find a card by either its
     // display name or its stable code (e.g., MarvelCDB-style "01001A").
-    return fuzzySearch(items, q, (it) => `${it.label} ${it.id}`);
+    return fuzzySearch(items, q, (it) => `${it.label} ${it.typeId}`);
   }, [items, query]);
 
   const handleClose = useCallback(() => {
@@ -502,12 +502,12 @@ function Step2ItemList({
           data-testid="load-picker-items"
         >
           {items.map((it) => (
-            <li key={it.id} className="load-picker-items-item">
+            <li key={it.typeId} className="load-picker-items-item">
               <button
                 type="button"
                 className="load-picker-item"
                 onClick={() => onPickItem(it)}
-                data-testid={`load-picker-item-${it.id}`}
+                data-testid={`load-picker-item-${it.typeId}`}
               >
                 {it.label}
               </button>
@@ -591,7 +591,7 @@ function CardPreviewIconButton({
       type="button"
       className="load-picker-card-preview-btn"
       aria-label={`Preview ${item.label}`}
-      data-testid={`load-picker-card-preview-${item.id}`}
+      data-testid={`load-picker-card-preview-${item.typeId}`}
       onClick={(e) => {
         // Always block the row select; the icon is its own affordance.
         e.stopPropagation();

--- a/app/src/content/index.test.ts
+++ b/app/src/content/index.test.ts
@@ -626,7 +626,7 @@ describe('loadLocalPluginAssets', () => {
             kind: 'static',
             items: [
               {
-                id: 'scenario-1',
+                typeId: 'scenario-1',
                 label: 'Scenario 1',
                 data: { file: 'scenario-1.json' },
               },

--- a/app/src/content/loadHandler.test.ts
+++ b/app/src/content/loadHandler.test.ts
@@ -132,7 +132,7 @@ describe('handleLoadSelection — replace + scenario', () => {
       gameAssets: makeAssets(),
     });
     const item = {
-      id: 's1',
+      typeId: 's1',
       label: 'Test',
       data: { file: 'testgame-basic.json' },
     };
@@ -164,7 +164,7 @@ describe('handleLoadSelection — replace + scenario', () => {
 
     await handleLoadSelection(
       scenarioEntry,
-      { id: 's1', label: 'Test', data: { file: 'testgame-basic.json' } },
+      { typeId: 's1', label: 'Test', data: { file: 'testgame-basic.json' } },
       { store, getViewportState },
     );
 
@@ -185,7 +185,7 @@ describe('handleLoadSelection — replace + scenario', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await handleLoadSelection(
       scenarioEntry,
-      { id: 'x', label: 'x', data: {} },
+      { typeId: 'x', label: 'x', data: {} },
       { store, getViewportState },
     );
     expect(warn).toHaveBeenCalled();
@@ -204,7 +204,7 @@ describe('handleLoadSelection — replace + non-scenario', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     await handleLoadSelection(
       entry,
-      { id: 'x', label: 'x', data: {} },
+      { typeId: 'x', label: 'x', data: {} },
       { store, getViewportState },
     );
     expect(warn).toHaveBeenCalledWith(
@@ -230,7 +230,7 @@ describe('handleLoadSelection — additive + card', () => {
     });
     await handleLoadSelection(
       cardEntry,
-      { id: '01001', label: '01001', data: { code: '01001' } },
+      { typeId: '01001', label: '01001', data: { code: '01001' } },
       { store, getViewportState },
     );
     expect(YjsActions.createObject).toHaveBeenCalledTimes(1);
@@ -253,7 +253,7 @@ describe('handleLoadSelection — additive + card', () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
     await handleLoadSelection(
       cardEntry,
-      { id: '01001', label: 'x', data: { code: '01001' } },
+      { typeId: '01001', label: 'x', data: { code: '01001' } },
       { store, getViewportState },
     );
     expect(YjsActions.createObject).not.toHaveBeenCalled();
@@ -295,12 +295,12 @@ describe('handleLoadSelection — additive + card', () => {
 
     await handleLoadSelection(
       cardEntry,
-      { id: '01001', label: '01001', data: { code: '01001' } },
+      { typeId: '01001', label: '01001', data: { code: '01001' } },
       { store, getViewportState: dpr1 },
     );
     await handleLoadSelection(
       cardEntry,
-      { id: '01001', label: '01001', data: { code: '01001' } },
+      { typeId: '01001', label: '01001', data: { code: '01001' } },
       { store, getViewportState: dpr2 },
     );
 
@@ -338,7 +338,7 @@ describe('handleLoadSelection — additive + card-set', () => {
     await handleLoadSelection(
       entry,
       {
-        id: 'encounter-basic',
+        typeId: 'encounter-basic',
         label: 'encounter-basic',
         data: { setName: 'encounter-basic' },
       },
@@ -364,7 +364,7 @@ describe('handleLoadSelection — additive + card-set', () => {
     await handleLoadSelection(
       entry,
       {
-        id: 'encounter-basic',
+        typeId: 'encounter-basic',
         label: 'Encounter Basic',
         data: { cardSet: 'encounter-basic' },
       },
@@ -385,7 +385,7 @@ describe('handleLoadSelection — additive + card-set', () => {
     };
     await handleLoadSelection(
       entry,
-      { id: 'x', label: 'x', data: { cardSet: 'unknown' } },
+      { typeId: 'x', label: 'x', data: { cardSet: 'unknown' } },
       { store, getViewportState },
     );
     expect(YjsActions.createObject).not.toHaveBeenCalled();

--- a/app/src/content/loadHandler.ts
+++ b/app/src/content/loadHandler.ts
@@ -176,7 +176,7 @@ export function readProviderLabels(
  */
 export async function handleLoadSelection(
   entry: LoadableEntry,
-  item: { id: string; label: string; data: unknown } | null,
+  item: { typeId: string; label: string; data: unknown } | null,
   deps: HandleLoadSelectionDeps,
 ): Promise<void> {
   if (entry.mode === 'replace') {
@@ -273,7 +273,7 @@ export async function handleLoadSelection(
 
   console.warn('[Load] Unrecognised additive item shape', {
     entryType: entry.type,
-    itemId: item.id,
+    itemId: item.typeId,
     data: item.data,
   });
 }

--- a/app/src/content/loadScenarioHelper.test.ts
+++ b/app/src/content/loadScenarioHelper.test.ts
@@ -472,7 +472,7 @@ describe('loadScenarioContent', () => {
             kind: 'static',
             items: [
               {
-                id: 'testgame-basic',
+                typeId: 'testgame-basic',
                 label: 'Test Game - Basic Setup',
                 data: { file: 'testgame-basic.json' },
               },
@@ -505,7 +505,7 @@ describe('loadScenarioContent', () => {
       // list keyed off mockContent.content.cards (CARD001, CARD002).
       expect(resolved[1].source.kind).toBe('static');
       if (resolved[1].source.kind === 'static') {
-        expect(resolved[1].source.items.map((i) => i.id).sort()).toEqual([
+        expect(resolved[1].source.items.map((i) => i.typeId).sort()).toEqual([
           'CARD001',
           'CARD002',
         ]);
@@ -521,7 +521,7 @@ describe('loadScenarioContent', () => {
           mode: 'replace',
           source: {
             kind: 'static',
-            items: [{ id: 'old', label: 'Old', data: {} }],
+            items: [{ typeId: 'old', label: 'Old', data: {} }],
           },
         },
       ];

--- a/app/src/content/loadablesRegistry.test.ts
+++ b/app/src/content/loadablesRegistry.test.ts
@@ -48,8 +48,8 @@ describe('loadablesRegistry', () => {
       source: {
         kind: 'static',
         items: [
-          { id: 's1', label: 'Scenario One', data: { file: 'one.json' } },
-          { id: 's2', label: 'Scenario Two', data: { file: 'two.json' } },
+          { typeId: 's1', label: 'Scenario One', data: { file: 'one.json' } },
+          { typeId: 's2', label: 'Scenario Two', data: { file: 'two.json' } },
         ],
       },
     };
@@ -113,14 +113,14 @@ describe('loadablesRegistry', () => {
     if (source.kind !== 'static') throw new Error('unreachable');
 
     expect(source.items).toHaveLength(3);
-    expect(source.items.map((i) => i.id).sort()).toEqual([
+    expect(source.items.map((i) => i.typeId).sort()).toEqual([
       '01001',
       '01002',
       '02001',
     ]);
-    // Each item carries id + label + data referencing the card code
-    expect(source.items[0].label).toBe(source.items[0].id);
-    expect(source.items[0].data).toEqual({ code: source.items[0].id });
+    // Each item carries typeId + label + data referencing the card code
+    expect(source.items[0].label).toBe(source.items[0].typeId);
+    expect(source.items[0].data).toEqual({ code: source.items[0].typeId });
   });
 
   it('uses the card name as the derived item label when name is non-empty', () => {
@@ -144,7 +144,7 @@ describe('loadablesRegistry', () => {
     if (source.kind !== 'static') throw new Error('unreachable');
 
     expect(source.items).toHaveLength(1);
-    expect(source.items[0].id).toBe('01001');
+    expect(source.items[0].typeId).toBe('01001');
     expect(source.items[0].label).toBe('Hero');
   });
 
@@ -179,7 +179,7 @@ describe('loadablesRegistry', () => {
 
       expect(source.items).toHaveLength(1);
       // Lower code wins (alphabetical) so hero/front side loads by default.
-      expect(source.items[0].id).toBe('01001A');
+      expect(source.items[0].typeId).toBe('01001A');
       expect(source.items[0].label).toBe('Spider-Man / Peter Parker');
       expect(source.items[0].data).toEqual({ code: '01001A' });
     });
@@ -198,7 +198,7 @@ describe('loadablesRegistry', () => {
       if (source.kind !== 'static') throw new Error('unreachable');
 
       expect(source.items).toHaveLength(1);
-      expect(source.items[0].id).toBe('01001A');
+      expect(source.items[0].typeId).toBe('01001A');
       expect(source.items[0].label).toBe('01001A / 01001B');
     });
 
@@ -220,7 +220,7 @@ describe('loadablesRegistry', () => {
       if (source.kind !== 'static') throw new Error('unreachable');
 
       expect(source.items).toHaveLength(1);
-      expect(source.items[0].id).toBe('02001A');
+      expect(source.items[0].typeId).toBe('02001A');
       expect(source.items[0].label).toBe('Encounter Front');
       expect(source.items[0].data).toEqual({ code: '02001A' });
     });
@@ -243,9 +243,9 @@ describe('loadablesRegistry', () => {
       // A emitted (asymmetric: A→B, B doesn't point back). B suppressed
       // (treated as image-only metadata for A). C reached as a singleton
       // (B never executes its asymmetric branch because A suppressed it).
-      const ids = source.items.map((i) => i.id).sort();
+      const ids = source.items.map((i) => i.typeId).sort();
       expect(ids).toEqual(['A', 'C']);
-      const aItem = source.items.find((i) => i.id === 'A');
+      const aItem = source.items.find((i) => i.typeId === 'A');
       expect(aItem?.label).toBe('A name');
     });
 
@@ -262,7 +262,7 @@ describe('loadablesRegistry', () => {
       if (source.kind !== 'static') throw new Error('unreachable');
 
       expect(source.items).toHaveLength(1);
-      expect(source.items[0].id).toBe('A');
+      expect(source.items[0].typeId).toBe('A');
       expect(source.items[0].label).toBe('A name');
       expect(source.items[0].data).toEqual({ code: 'A' });
     });
@@ -289,7 +289,7 @@ describe('loadablesRegistry', () => {
       if (source.kind !== 'static') throw new Error('unreachable');
 
       expect(source.items).toHaveLength(4);
-      const byId = Object.fromEntries(source.items.map((i) => [i.id, i]));
+      const byId = Object.fromEntries(source.items.map((i) => [i.typeId, i]));
       expect(byId['01001A']?.label).toBe('Hero / Alter');
       expect(byId['02001A']?.label).toBe('Front');
       expect(byId['03001']?.label).toBe('Solo');
@@ -321,7 +321,7 @@ describe('loadablesRegistry', () => {
       if (source.kind !== 'static') throw new Error('unreachable');
 
       expect(source.items).toHaveLength(1);
-      expect(source.items[0].id).toBe('01001A');
+      expect(source.items[0].typeId).toBe('01001A');
       expect(source.items[0].label).toBe('Spider-Man / Peter Parker');
     });
   });
@@ -348,11 +348,13 @@ describe('loadablesRegistry', () => {
     expect(source.kind).toBe('static');
     if (source.kind !== 'static') throw new Error('unreachable');
 
-    expect(source.items.map((i) => i.id).sort()).toEqual([
+    expect(source.items.map((i) => i.typeId).sort()).toEqual([
       'captain_america_nemesis',
       'spider_man_nemesis',
     ]);
-    const spiderItem = source.items.find((i) => i.id === 'spider_man_nemesis');
+    const spiderItem = source.items.find(
+      (i) => i.typeId === 'spider_man_nemesis',
+    );
     expect(spiderItem?.label).toBe('spider_man_nemesis');
     expect(spiderItem?.data).toEqual({ setName: 'spider_man_nemesis' });
   });
@@ -386,7 +388,7 @@ describe('loadablesRegistry', () => {
         mode: 'replace',
         source: {
           kind: 'static',
-          items: [{ id: 's1', label: 'Scen 1', data: { file: 's1.json' } }],
+          items: [{ typeId: 's1', label: 'Scen 1', data: { file: 's1.json' } }],
         },
       },
       {
@@ -449,7 +451,7 @@ describe('loadablesRegistry', () => {
       mode: 'replace',
       source: {
         kind: 'static',
-        items: [{ id: 's1', label: 'S', data: {} }],
+        items: [{ typeId: 's1', label: 'S', data: {} }],
       },
     };
 
@@ -520,8 +522,8 @@ describe('loadablesRegistry', () => {
       source: {
         kind: 'static',
         items: [
-          { id: 's1', label: 'Scenario One', data: { file: 'one.json' } },
-          { id: 's2', label: 'Scenario Two', data: { file: 'two.json' } },
+          { typeId: 's1', label: 'Scenario One', data: { file: 'one.json' } },
+          { typeId: 's2', label: 'Scenario Two', data: { file: 'two.json' } },
         ],
       },
     };
@@ -571,7 +573,11 @@ describe('loadablesRegistry', () => {
           source: {
             kind: 'static',
             items: [
-              { id: 's3', label: 'Scenario 3', data: { file: 'three.json' } },
+              {
+                typeId: 's3',
+                label: 'Scenario 3',
+                data: { file: 'three.json' },
+              },
             ],
           },
         };
@@ -624,7 +630,7 @@ describe('loadablesRegistry', () => {
         const items = getStaticItems<{ code: string }>(resolved, 'card');
         expect(items).toHaveLength(1);
         expect(items[0]).toEqual({
-          id: '01001',
+          typeId: '01001',
           label: 'Hero',
           data: { code: '01001' },
         });

--- a/app/src/content/loadablesRegistry.ts
+++ b/app/src/content/loadablesRegistry.ts
@@ -185,7 +185,7 @@ function deriveItems(
     //
     // Cases:
     //  1. Bidirectional pair (A.back_code=B AND B.back_code=A):
-    //     emit one item; id/data.code = lexicographically lower code
+    //     emit one item; typeId/data.code = lexicographically lower code
     //     (matches MC's A/B convention so the hero/scheme-front loads first).
     //     Label: `${lower.name||lowerCode} / ${higher.name||higherCode}`.
     //  2. Asymmetric (A.back_code=B but B.back_code !== A, or B has no
@@ -214,7 +214,7 @@ function deriveItems(
           const lowerLabel = lowerCard.name || lowerCode;
           const higherLabel = higherCard.name || higherCode;
           items.push({
-            id: lowerCode,
+            typeId: lowerCode,
             label: `${lowerLabel} / ${higherLabel}`,
             data: { code: lowerCode },
           });
@@ -227,7 +227,7 @@ function deriveItems(
           // Asymmetric: A points at B but B doesn't point back. Emit A;
           // mark B emitted so it never appears as a separate entry.
           items.push({
-            id: code,
+            typeId: code,
             label: card.name || code,
             data: { code },
           });
@@ -242,7 +242,7 @@ function deriveItems(
 
       // Singleton (no back_code, self-reference, or dangling pointer).
       items.push({
-        id: code,
+        typeId: code,
         label: card.name || code,
         data: { code },
       });
@@ -254,7 +254,7 @@ function deriveItems(
 
   // 'all-card-sets'
   return Object.keys(gameAssets.cardSets).map((setName) => ({
-    id: setName,
+    typeId: setName,
     label: setName,
     data: { setName },
   }));

--- a/app/src/content/pluginLoader.test.ts
+++ b/app/src/content/pluginLoader.test.ts
@@ -57,7 +57,7 @@ const mockManifest: PluginManifest = {
         kind: 'static',
         items: [
           {
-            id: 'test-scenario',
+            typeId: 'test-scenario',
             label: 'Test Scenario',
             data: { file: 'test-scenario.json' },
           },
@@ -351,7 +351,7 @@ describe('loadPluginManifest', () => {
             kind: 'static',
             items: [
               {
-                id: 's1',
+                typeId: 's1',
                 label: 'Scenario 1',
                 data: { file: 's1.json' },
               },
@@ -884,7 +884,7 @@ describe('loadLocalPluginDirectory', () => {
             kind: 'static',
             items: [
               {
-                id: 'scenario1',
+                typeId: 'scenario1',
                 label: 'Scenario 1',
                 data: { file: 'scenario1.json' },
               },
@@ -956,7 +956,7 @@ describe('loadLocalPluginDirectory', () => {
             kind: 'static',
             items: [
               {
-                id: 'missing-scenario',
+                typeId: 'missing-scenario',
                 label: 'Missing Scenario',
                 data: { file: 'missing-scenario.json' },
               },
@@ -1084,12 +1084,12 @@ describe('getPluginScenarioUrls', () => {
           kind: 'static',
           items: [
             {
-              id: 's1',
+              typeId: 's1',
               label: 'Scenario 1',
               data: { file: 'scenarios/one.json' },
             },
             {
-              id: 's2',
+              typeId: 's2',
               label: 'Scenario 2',
               data: { file: 'scenarios/two.json' },
             },

--- a/app/src/routes/dev.table.$id.tsx
+++ b/app/src/routes/dev.table.$id.tsx
@@ -287,7 +287,7 @@ function DevTable() {
   const resolveDerivedItems = useCallback<DerivedItemsResolver>((entry) => {
     if (entry.source.kind === 'static') {
       return entry.source.items.map((it) => ({
-        id: it.id,
+        typeId: it.typeId,
         label: it.label,
         data: it.data,
       }));

--- a/app/src/routes/table.$id.tsx
+++ b/app/src/routes/table.$id.tsx
@@ -697,7 +697,7 @@ function Table() {
   const resolveDerivedItems = useCallback<DerivedItemsResolver>((entry) => {
     if (entry.source.kind === 'static') {
       return entry.source.items.map((it) => ({
-        id: it.id,
+        typeId: it.typeId,
         label: it.label,
         data: it.data,
       }));

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -291,7 +291,7 @@ export type LoadableMode = 'additive' | 'replace';
  * shared-schema layer; per-type narrowing happens in the consumer.
  */
 export interface LoadableStaticItem<TData = unknown> {
-  id: string; // Stable identifier within this loadable type
+  typeId: string; // Stable identifier within this loadable type
   label: string; // Display label for the picker
   data: TData; // Type-specific payload (e.g. scenario file path, card code)
 }


### PR DESCRIPTION
## Summary
- Project rule clarified: the field name `id` is reserved for unique board instances. The loadables system's `LoadableStaticItem` envelope previously reused `id` for the stable identifier within a loadable type — blurred the contract.
- Renames the envelope field from `id` to `typeId` system-wide across source (`shared/`, `app/src/content/`, components, routes), test fixtures (7 files), and the in-repo `testgame` plugin manifest.
- 15 files, +99/-81. Tests: 1231 passing (was 1224 + ~7 test-fixture cases counted here too — net green).

## Action item before merge
The agent could not reach `/Users/erlloyd/Code/cardtable-plugin-marvelchampions/` (outside its sandbox). That repo's manifests still use `"id"` and will fail to surface as typed-counter / card / component-set items once this lands on main. Tracking via **ct-838** — either fix the plugin repo in lockstep or add it to the agent sandbox and rerun for that repo.

## Followups also affected
- PR #112 (ct-209 counters loadable) is on hold pending this merge; will be rebased to use `typeId` after.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (1231 passing)
- [x] No suppressions, no `typeof` for internal validation, no inline `import()` casts
- [ ] Verify dev server still loads the testgame plugin cleanly (manual spot-check after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)