### PR TITLE
chore(bd): disable export.auto to silence gitignored-jsonl warnings (ct-1n3)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -54,3 +54,5 @@
 # - github.repo
 
 sync.remote: 'git+ssh://git@github.com/erlloyd/cardtable2.git'
+
+export.auto: false


### PR DESCRIPTION
## Summary
- `.beads/issues.jsonl` is gitignored project-wide; with bd's default `export.auto=true`, every bd command attempts a `git add` on the gitignored file and prints `auto-export: git add failed: paths ignored by one of your .gitignore files`.
- The plugin sibling repo (cardtable-plugin-marvelchampions) already has `export.auto: false` in `.beads/config.yaml` for the same reason. This brings cardtable2 in line.
- Committing the config so contributors, sub-agent worktrees, and fresh checkouts inherit the silenced behavior.

## Test plan
- [x] `bd -C <repo> config get export.auto` returns `false`
- [x] `bd ready` runs cleanly with no auto-export warnings
- [ ] After merge, fresh checkouts / new agent worktrees inherit the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)