### PR TITLE
feat(counter): wire +/- interaction with state-aware visuals (ct-d2p)

### DIFF
--- a/app/src/actions/registerDefaultActions.test.ts
+++ b/app/src/actions/registerDefaultActions.test.ts
@@ -227,3 +227,122 @@ describe('registerLoadablesActions / per-type Load <X>… actions', () => {
     ).toBeUndefined();
   });
 });
+
+describe('Counter increment/decrement actions (ct-d2p)', () => {
+  beforeEach(() => {
+    ActionRegistry.getInstance().clear();
+    registerDefaultActions();
+  });
+
+  afterEach(() => {
+    ActionRegistry.getInstance().clear();
+  });
+
+  function counterContext(
+    overrides: Partial<ActionContext> = {},
+  ): ActionContext {
+    return makeContext({
+      selection: {
+        ids: ['counter-1'],
+        yMaps: [],
+        count: 1,
+        hasStacks: false,
+        hasTokens: false,
+        hasCounters: true,
+        hasMixed: false,
+        allLocked: false,
+        allUnlocked: true,
+        canAct: true,
+      },
+      ...overrides,
+    });
+  }
+
+  it('registers a counter-increment action bound to the "=" key (the unshifted form of "+")', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(action).toBeDefined();
+    expect(action?.shortcut).toBe('=');
+  });
+
+  it('registers a counter-decrement action bound to "-"', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-decrement');
+    expect(action).toBeDefined();
+    expect(action?.shortcut).toBe('-');
+  });
+
+  it('increment is available when exactly one Counter is selected', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(action?.isAvailable(counterContext())).toBe(true);
+  });
+
+  it('increment is NOT available when selection is empty', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(action?.isAvailable(makeContext())).toBe(false);
+  });
+
+  it('increment is NOT available when selection contains 2+ counters', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(
+      action?.isAvailable(
+        counterContext({
+          selection: {
+            ids: ['counter-1', 'counter-2'],
+            yMaps: [],
+            count: 2,
+            hasStacks: false,
+            hasTokens: false,
+            hasCounters: true,
+            hasMixed: false,
+            allLocked: false,
+            allUnlocked: true,
+            canAct: true,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('increment is NOT available for mixed selections', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(
+      action?.isAvailable(
+        counterContext({
+          selection: {
+            ids: ['counter-1', 'stack-1'],
+            yMaps: [],
+            count: 2,
+            hasStacks: true,
+            hasTokens: false,
+            hasCounters: true,
+            hasMixed: true,
+            allLocked: false,
+            allUnlocked: true,
+            canAct: true,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('increment is NOT available when the sole selected object is not a counter', () => {
+    const action = ActionRegistry.getInstance().getAction('counter-increment');
+    expect(
+      action?.isAvailable(
+        counterContext({
+          selection: {
+            ids: ['stack-1'],
+            yMaps: [],
+            count: 1,
+            hasStacks: true,
+            hasTokens: false,
+            hasCounters: false,
+            hasMixed: false,
+            allLocked: false,
+            allUnlocked: true,
+            canAct: true,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -1,5 +1,10 @@
 import { ActionRegistry } from './ActionRegistry';
-import { CARD_ACTIONS, VIEW_ACTIONS, CONTENT_ACTIONS } from './types';
+import {
+  CARD_ACTIONS,
+  VIEW_ACTIONS,
+  CONTENT_ACTIONS,
+  type ActionContext,
+} from './types';
 import { registerAttachmentActions } from './attachmentActions';
 import type { LoadableEntry } from '@cardtable2/shared';
 import {
@@ -10,6 +15,7 @@ import {
   shuffleStack,
   detachCard,
   detachAllCards,
+  adjustCounter,
 } from '../store/YjsActions';
 import {
   areAllSelectedStacksExhausted,
@@ -232,6 +238,61 @@ export function registerDefaultActions(): void {
       const detached = detachAllCards(ctx.store, parentId);
       console.log(`Detached ${detached.length} cards from ${parentId}`);
     },
+  });
+
+  // ct-d2p: Counter +/- keyboard shortcuts. Available only when exactly
+  // one Counter is selected (gated via `hasCounters` + `count === 1` to
+  // match the pill's UI affordance — multi-counter batch adjusts are not
+  // in scope for this bead). `=` (unshifted form of `+` on US keyboards)
+  // and `-` are both registered as plain single-character shortcuts.
+  //
+  // Bare `'+'` is NOT registered as a shortcut because
+  // `KeyboardManager.normalizeShortcut` uses `'+'` as the modifier
+  // separator and splits `'+'.split('+')` into `['', '']`, which
+  // normalizes to the empty string and never matches a real key event.
+  // The shifted form (`Shift+=`) suffers a symmetric issue: a real
+  // `Shift+=` keypress dispatches `event.key === '+'`, which the
+  // normalizer then joins as `'Shift++'` (since `'+'` is also the join
+  // separator), so no static shortcut string can target it cleanly.
+  //
+  // See investigation bead filed via `bd create` from this task. The
+  // unshifted `=` is enough to satisfy the spec's "plus/equals" wording
+  // until the underlying parser is fixed.
+  const counterIncrementIsAvailable = (ctx: ActionContext): boolean =>
+    ctx.selection.count === 1 &&
+    ctx.selection.hasCounters &&
+    !ctx.selection.hasMixed;
+  const counterIncrementExecute = (ctx: ActionContext): void => {
+    const id = ctx.selection.ids[0];
+    adjustCounter(ctx.store, id, 1);
+  };
+  const counterDecrementExecute = (ctx: ActionContext): void => {
+    const id = ctx.selection.ids[0];
+    adjustCounter(ctx.store, id, -1);
+  };
+
+  registry.register({
+    id: 'counter-increment',
+    label: 'Increment Counter',
+    shortLabel: '+1',
+    icon: '➕',
+    shortcut: '=',
+    category: CARD_ACTIONS,
+    description: 'Increment the selected counter by 1',
+    isAvailable: counterIncrementIsAvailable,
+    execute: counterIncrementExecute,
+  });
+
+  registry.register({
+    id: 'counter-decrement',
+    label: 'Decrement Counter',
+    shortLabel: '-1',
+    icon: '➖',
+    shortcut: '-',
+    category: CARD_ACTIONS,
+    description: 'Decrement the selected counter by 1',
+    isAvailable: counterIncrementIsAvailable,
+    execute: counterDecrementExecute,
   });
 
   // Object action: Lock/Unlock (works on any object)

--- a/app/src/components/Board/BoardMessageBus.ts
+++ b/app/src/components/Board/BoardMessageBus.ts
@@ -14,6 +14,7 @@ import {
   unstackCard,
   attachCards,
   detachCard,
+  adjustCounter,
 } from '../../store/YjsActions';
 import { getSelectedObjectIds } from '../../store/YjsSelectors';
 import { resolveEffectiveAttachmentLayout } from '../../store/attachmentLayout';
@@ -287,6 +288,28 @@ export class BoardMessageBus {
               : error,
         });
         ctx.addMessage('Failed to detach card.');
+      }
+    });
+
+    // ct-d2p: Counter +/- zone tap from the renderer.
+    this.registry.register('counter-adjust', (msg, ctx) => {
+      try {
+        const result = adjustCounter(ctx.store, msg.id, msg.delta);
+        if (!result) {
+          console.warn(
+            '[BoardMessageBus] counter-adjust ignored: counter not found',
+            { id: msg.id, delta: msg.delta },
+          );
+        }
+      } catch (error) {
+        console.error('[BoardMessageBus] Counter adjust failed', {
+          id: msg.id,
+          delta: msg.delta,
+          error:
+            error instanceof Error
+              ? { message: error.message, stack: error.stack }
+              : error,
+        });
       }
     });
 

--- a/app/src/renderer/handlers/pointer.ts
+++ b/app/src/renderer/handlers/pointer.ts
@@ -21,11 +21,34 @@ import {
   STACK_BADGE_SIZE,
 } from '../objects/stack/constants';
 import { getCardCount } from '../objects/stack/utils';
+import {
+  counterZoneAtPoint,
+  isCounterZoneAtBoundary,
+} from '../objects/counter/utils';
+import type { CounterZone } from '../managers/HoverManager';
 
 /**
  * Track last sent cursor style to avoid sending redundant messages
  */
 let lastCursorStyle: 'default' | 'pointer' | 'grab' | 'grabbing' = 'default';
+
+/**
+ * Classify the hovered Counter sub-zone for the given world point (ct-d2p).
+ *
+ * Returns `null` when the object isn't a Counter or the point isn't over
+ * one of the side (+/-) zones. The center "value" zone yields `null` —
+ * only side zones are interactive.
+ */
+function classifyCounterZone(
+  worldX: number,
+  worldY: number,
+  obj: TableObject,
+): CounterZone {
+  if (obj._kind !== ObjectKind.Counter) return null;
+  const zone = counterZoneAtPoint(worldX, worldY, obj);
+  if (zone === 'minus' || zone === 'plus') return zone;
+  return null;
+}
 
 /**
  * Helper: Check if a world position is in the bottom third of a stack (attach zone)
@@ -569,7 +592,8 @@ export function handlePointerMove(
 
     // Update hover state if changed
     const prevId = context.hover.getHoveredObjectId();
-    if (context.hover.setHoveredObject(newHoveredId)) {
+    const hoverChanged = context.hover.setHoveredObject(newHoveredId);
+    if (hoverChanged) {
       // Clear previous hover
       if (prevId) {
         const isSelected = context.selection.isSelected(prevId);
@@ -627,6 +651,32 @@ export function handlePointerMove(
 
       // Request render to show hover feedback
       context.app.renderer.render(context.app.stage);
+    }
+
+    // ct-d2p: Counter sub-zone hover state. Runs on every pointermove over
+    // a hovered counter (not just hover transitions) because the relevant
+    // zone changes as the pointer slides between the -/center/+ thirds
+    // without leaving the pill.
+    const counterHoverId = context.hover.getHoveredObjectId();
+    const counterObj = counterHoverId
+      ? context.sceneManager.getObject(counterHoverId)
+      : null;
+    if (counterObj && counterObj._kind === ObjectKind.Counter) {
+      const newZone = classifyCounterZone(worldPos.x, worldPos.y, counterObj);
+      if (context.hover.setHoveredCounterZone(newZone)) {
+        const isSelected = context.selection.isSelected(counterHoverId!);
+        context.visual.updateCounterZoneFeedback(
+          counterHoverId!,
+          newZone,
+          isSelected,
+          true,
+          context.sceneManager,
+        );
+        context.app.renderer.render(context.app.stage);
+      }
+    } else if (context.hover.getHoveredCounterZone() !== null) {
+      // Pointer left counter / no counter hovered — clear residual zone.
+      context.hover.setHoveredCounterZone(null);
     }
   } else {
     // Clear hover when not applicable (touch, dragging, or pinching)
@@ -976,6 +1026,36 @@ function handleSelectionOnPointerEnd(
             ids: [],
             screenCoords: [],
           });
+        }
+      }
+
+      // ct-d2p: If the click landed on a Counter's +/- zone, fire an
+      // adjust (or clamp-flash if at boundary). Selection has already been
+      // updated above so the keyboard shortcut also activates immediately.
+      if (hitResult.object._kind === ObjectKind.Counter) {
+        const zone = counterZoneAtPoint(worldX, worldY, hitResult.object);
+        if (zone === 'minus' || zone === 'plus') {
+          const atBoundary = isCounterZoneAtBoundary(hitResult.object, zone);
+          const isHovered = context.hover.getHoveredObjectId() === hitResult.id;
+          const isSelected = context.selection.isSelected(hitResult.id);
+          if (atBoundary) {
+            // Boundary tap: don't post adjust; just flash the body.
+            context.visual.flashCounterClamp(
+              hitResult.id,
+              zone,
+              isSelected,
+              isHovered,
+              context.sceneManager,
+            );
+            context.app.renderer.render(context.app.stage);
+          } else {
+            const delta = zone === 'plus' ? 1 : -1;
+            context.postResponse({
+              type: 'counter-adjust',
+              id: hitResult.id,
+              delta,
+            });
+          }
         }
       }
 

--- a/app/src/renderer/handlers/pointer.ts
+++ b/app/src/renderer/handlers/pointer.ts
@@ -178,9 +178,30 @@ export function handlePointerDown(
         selectedCount <= 1 &&
         isPointInUnstackHandle(worldPos.x, worldPos.y, hitResult.object);
 
+      // ct-m3h: A pointer-down on a Counter's +/- side zone is a click-only
+      // affordance — it must never promote to a drag, because even sub-pixel
+      // mouse jitter past the 3px drag-slop threshold during the down→up
+      // window would otherwise classify the interaction as a drag and gate
+      // out the counter-adjust on pointer-up. Skip drag prep entirely for
+      // those zones; the center "value" zone keeps the normal drag prep so
+      // users can still pick up a counter by its body. (Pre-fix, ~50% of
+      // rapid taps were silently dropped because rapid tapping inevitably
+      // produces 3-5px hand jitter mid-click.)
+      const counterClickZone =
+        hitResult.object._kind === ObjectKind.Counter
+          ? counterZoneAtPoint(worldPos.x, worldPos.y, hitResult.object)
+          : null;
+      const isCounterSideZoneClick =
+        counterClickZone === 'minus' || counterClickZone === 'plus';
+
       if (isUnstackHandleClick) {
         // Clicking on unstack handle - prepare for unstack drag
         context.drag.prepareUnstackDrag(hitResult.id, worldPos.x, worldPos.y);
+      } else if (isCounterSideZoneClick) {
+        // ct-m3h: Don't prepare a drag — counter +/- zones are click-only.
+        // Reset any stale prep from a previous interaction so getDraggedObjectId
+        // returns null in handlePointerMove and no drag can start.
+        context.drag.resetAll();
       } else {
         // Clicking on a card - always prepare for object drag (regardless of mode)
         context.drag.prepareObjectDrag(hitResult.id, worldPos.x, worldPos.y);

--- a/app/src/renderer/managers/HoverManager.ts
+++ b/app/src/renderer/managers/HoverManager.ts
@@ -8,8 +8,17 @@
  *
  * Extracted from RendererCore (Phase 1 - Hybrid Architecture Refactor).
  */
+/**
+ * Sub-region of a Counter pill that the pointer is currently over (ct-d2p).
+ * `null` when the pointer is not over a counter or is over the center
+ * (value-display) zone — the +/- side zones are the only interactive
+ * sub-regions.
+ */
+export type CounterZone = 'minus' | 'plus' | null;
+
 export class HoverManager {
   private hoveredObjectId: string | null = null;
+  private hoveredCounterZone: CounterZone = null;
 
   /**
    * Get the currently hovered object ID.
@@ -35,6 +44,29 @@ export class HoverManager {
     }
 
     this.hoveredObjectId = objectId;
+    // Hover left the previous object — its zone state is meaningless now.
+    // Counter-specific zone updates happen via setHoveredCounterZone.
+    this.hoveredCounterZone = null;
+    return true;
+  }
+
+  /**
+   * Get the currently hovered Counter sub-zone (ct-d2p).
+   * Returns `null` whenever the pointer is not over a Counter side-zone.
+   */
+  getHoveredCounterZone(): CounterZone {
+    return this.hoveredCounterZone;
+  }
+
+  /**
+   * Set the hovered Counter sub-zone (ct-d2p).
+   * @returns True if the zone state changed and the visual should redraw.
+   */
+  setHoveredCounterZone(zone: CounterZone): boolean {
+    if (this.hoveredCounterZone === zone) {
+      return false;
+    }
+    this.hoveredCounterZone = zone;
     return true;
   }
 
@@ -44,6 +76,7 @@ export class HoverManager {
   clearHover(objectId: string): void {
     if (this.hoveredObjectId === objectId) {
       this.hoveredObjectId = null;
+      this.hoveredCounterZone = null;
     }
   }
 
@@ -52,6 +85,7 @@ export class HoverManager {
    */
   clearAll(): void {
     this.hoveredObjectId = null;
+    this.hoveredCounterZone = null;
   }
 
   /**

--- a/app/src/renderer/managers/VisualManager.ts
+++ b/app/src/renderer/managers/VisualManager.ts
@@ -3,16 +3,17 @@ import type { TextOptions } from 'pixi.js';
 import type { TableObject, GameAssets } from '@cardtable2/shared';
 import { ObjectKind } from '@cardtable2/shared';
 import { getBehaviors } from '../objects';
-import type { RenderContext } from '../objects/types';
+import type { CounterZoneState, RenderContext } from '../objects/types';
 import { createScaleStrokeWidth } from '../handlers/objects';
 import type { TextureLoader } from '../services/TextureLoader';
 import { STACK_WIDTH, STACK_HEIGHT } from '../objects/stack/constants';
 import { getTokenSize } from '../objects/token/utils';
 import { getMatSize } from '../objects/mat/utils';
 import { getCounterDimensions } from '../objects/counter/utils';
+import { COUNTER_CLAMP_FLASH_DURATION_MS } from '../objects/counter/constants';
 import type { SceneManager } from '../SceneManager';
 import type { SelectionManager } from './SelectionManager';
-import type { HoverManager } from './HoverManager';
+import type { CounterZone, HoverManager } from './HoverManager';
 import { RenderMode } from '../IRendererAdapter';
 
 /**
@@ -65,6 +66,12 @@ export class VisualManager {
 
   // Track objects hidden due to remote awareness drag (only show ghost)
   private hiddenObjectIds: Set<string> = new Set();
+
+  // ct-d2p: Counter clamp-flash state. Maps counter object IDs to the
+  // setTimeout handle that clears the flash; presence of an entry implies
+  // the flash overlay should be drawn on the next render.
+  private counterClampFlashes: Map<string, ReturnType<typeof setTimeout>> =
+    new Map();
 
   /**
    * Initialize with app reference.
@@ -476,11 +483,87 @@ export class VisualManager {
       isHovered?: boolean;
       isDragging?: boolean;
       isSelected?: boolean;
+      counterZoneState?: CounterZoneState;
       preservePosition?: boolean;
       preserveScale?: boolean;
     },
   ): void {
     this.redrawVisual(objectId, sceneManager, options);
+  }
+
+  /**
+   * Redraw a counter to reflect a change in its hovered sub-zone (ct-d2p).
+   * The zone state is supplied explicitly rather than read from HoverManager
+   * to keep this manager free of upward dependencies.
+   */
+  updateCounterZoneFeedback(
+    objectId: string,
+    hoveredZone: CounterZone,
+    isSelected: boolean,
+    isHovered: boolean,
+    sceneManager: SceneManager,
+  ): void {
+    const visual = this.objectVisuals.get(objectId);
+    if (!visual) return;
+    const clampFlash = this.counterClampFlashes.has(objectId);
+    this.redrawVisual(objectId, sceneManager, {
+      isSelected,
+      isHovered,
+      counterZoneState: { hoveredZone, clampFlash },
+    });
+  }
+
+  /**
+   * Flash a counter's pill body to signal a clamped (min/max) tap (ct-d2p).
+   *
+   * Triggers an immediate redraw with the flash overlay, then schedules a
+   * second redraw to clear it after `COUNTER_CLAMP_FLASH_DURATION_MS`.
+   * Calling again while a flash is active resets the timer so consecutive
+   * taps don't truncate the visual.
+   */
+  flashCounterClamp(
+    objectId: string,
+    hoveredZone: CounterZone,
+    isSelected: boolean,
+    isHovered: boolean,
+    sceneManager: SceneManager,
+  ): void {
+    const visual = this.objectVisuals.get(objectId);
+    if (!visual) return;
+
+    // Reset any in-flight flash for this object so the duration restarts.
+    const existing = this.counterClampFlashes.get(objectId);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.counterClampFlashes.delete(objectId);
+      // Re-check the object still exists; it may have been removed during
+      // the flash window. We pass the latest hover state we know about;
+      // callers that need a stricter refresh can call
+      // updateCounterZoneFeedback after the flash.
+      if (
+        this.objectVisuals.has(objectId) &&
+        sceneManager.getObject(objectId)
+      ) {
+        this.redrawVisual(objectId, sceneManager, {
+          isSelected,
+          isHovered,
+          counterZoneState: { hoveredZone, clampFlash: false },
+        });
+        if (this.app) {
+          this.app.renderer.render(this.app.stage);
+        }
+      }
+    }, COUNTER_CLAMP_FLASH_DURATION_MS);
+    this.counterClampFlashes.set(objectId, timer);
+
+    this.redrawVisual(objectId, sceneManager, {
+      isSelected,
+      isHovered,
+      counterZoneState: { hoveredZone, clampFlash: true },
+    });
   }
 
   /**
@@ -534,6 +617,7 @@ export class VisualManager {
       dragActionPreview?: 'stack' | 'attach' | null;
       isStackTarget?: boolean;
       isAttachTarget?: boolean;
+      counterZoneState?: CounterZoneState;
       preservePosition?: boolean;
       preserveScale?: boolean;
     },
@@ -546,6 +630,7 @@ export class VisualManager {
       dragActionPreview = null,
       isStackTarget = false,
       isAttachTarget = false,
+      counterZoneState,
       preservePosition = false,
       preserveScale = false,
     } = options ?? {};
@@ -659,6 +744,8 @@ export class VisualManager {
       sceneManager,
       isAttachTarget,
       dragActionPreview,
+      isHovered,
+      counterZoneState,
     );
     visual.addChild(shapeGraphic);
 
@@ -711,6 +798,7 @@ export class VisualManager {
       gameAssets: overrides.gameAssets ?? this.gameAssets,
       textureLoader: overrides.textureLoader ?? this.textureLoader ?? undefined,
       onTextureLoaded: overrides.onTextureLoaded,
+      counterZoneState: overrides.counterZoneState,
     };
 
     return ctx;
@@ -728,6 +816,8 @@ export class VisualManager {
     sceneManager: SceneManager,
     isAttachTarget: boolean = false,
     dragActionPreview: 'stack' | 'attach' | null = null,
+    isHovered: boolean = false,
+    counterZoneState?: CounterZoneState,
   ): Container {
     const behaviors = getBehaviors(obj._kind);
     return behaviors.render(
@@ -735,9 +825,11 @@ export class VisualManager {
       this.buildRenderContext({
         objectId,
         isSelected,
+        isHovered,
         isStackTarget,
         isAttachTarget,
         dragActionPreview,
+        counterZoneState,
         onTextureLoaded: (_url: string) => {
           // Skip re-render if shuffle animation is in progress (would destroy ghost rectangles)
           if (this.animationManager?.isShuffling(objectId)) {

--- a/app/src/renderer/objects/counter/behaviors.test.ts
+++ b/app/src/renderer/objects/counter/behaviors.test.ts
@@ -8,7 +8,11 @@ import {
   COUNTER_PILL_HEIGHT,
   COUNTER_PILL_WIDTH,
 } from './constants';
-import { getCounterDimensions } from './utils';
+import {
+  counterZoneAtPoint,
+  getCounterDimensions,
+  isCounterZoneAtBoundary,
+} from './utils';
 
 // Helper to create test counter objects with all required CounterMeta fields.
 function createTestCounter(
@@ -96,6 +100,64 @@ describe('getCounterDimensions', () => {
       width: COUNTER_PILL_WIDTH,
       height: COUNTER_PILL_HEIGHT,
     });
+  });
+});
+
+describe('counterZoneAtPoint (ct-d2p)', () => {
+  it('classifies the left third as minus', () => {
+    const counter = createTestCounter({ _pos: { x: 0, y: 0, r: 0 } });
+    // Pill width 90, third = 30, left third spans local x in [-45, -15].
+    expect(counterZoneAtPoint(-30, 0, counter)).toBe('minus');
+  });
+
+  it('classifies the right third as plus', () => {
+    const counter = createTestCounter({ _pos: { x: 0, y: 0, r: 0 } });
+    expect(counterZoneAtPoint(30, 0, counter)).toBe('plus');
+  });
+
+  it('classifies the center third as value', () => {
+    const counter = createTestCounter({ _pos: { x: 0, y: 0, r: 0 } });
+    expect(counterZoneAtPoint(0, 0, counter)).toBe('value');
+  });
+
+  it('returns null for points outside the pill bounds', () => {
+    const counter = createTestCounter({ _pos: { x: 0, y: 0, r: 0 } });
+    // x just past +45 (half-width) at y=0.
+    expect(counterZoneAtPoint(50, 0, counter)).toBeNull();
+    // y past half-height (22).
+    expect(counterZoneAtPoint(0, 30, counter)).toBeNull();
+  });
+
+  it('respects pill _pos translation', () => {
+    const counter = createTestCounter({ _pos: { x: 100, y: 50, r: 0 } });
+    // World point (130, 50) is +30 in local-x = plus zone.
+    expect(counterZoneAtPoint(130, 50, counter)).toBe('plus');
+    // World point (70, 50) is -30 in local-x = minus zone.
+    expect(counterZoneAtPoint(70, 50, counter)).toBe('minus');
+  });
+});
+
+describe('isCounterZoneAtBoundary (ct-d2p)', () => {
+  it('returns true when currentValue is at max for plus zone', () => {
+    const counter = createTestCounter({
+      meta: { currentValue: 99, max: 99 },
+    });
+    expect(isCounterZoneAtBoundary(counter, 'plus')).toBe(true);
+    expect(isCounterZoneAtBoundary(counter, 'minus')).toBe(false);
+  });
+
+  it('returns true when currentValue is at min for minus zone', () => {
+    const counter = createTestCounter({ meta: { currentValue: 0, min: 0 } });
+    expect(isCounterZoneAtBoundary(counter, 'minus')).toBe(true);
+    expect(isCounterZoneAtBoundary(counter, 'plus')).toBe(false);
+  });
+
+  it('returns false away from both boundaries', () => {
+    const counter = createTestCounter({
+      meta: { currentValue: 5, min: 0, max: 10 },
+    });
+    expect(isCounterZoneAtBoundary(counter, 'minus')).toBe(false);
+    expect(isCounterZoneAtBoundary(counter, 'plus')).toBe(false);
   });
 });
 
@@ -236,5 +298,118 @@ describe('Counter Behaviors - Rendering', () => {
     expect(container).toBeInstanceOf(Container);
     // In minimal mode only the pill body is rendered — no text calls.
     expect(mockCreateText).not.toHaveBeenCalled();
+  });
+
+  describe('state-aware zone visuals (ct-d2p)', () => {
+    function getGlyphByLabel(
+      container: Container,
+      label: string,
+    ): Text | undefined {
+      return container.children.find((c) => c.label === label) as
+        | Text
+        | undefined;
+    }
+
+    function getChildByLabel(
+      container: Container,
+      label: string,
+    ): Container | undefined {
+      return container.children.find((c) => c.label === label) as
+        | Container
+        | undefined;
+    }
+
+    it('renders both glyphs at the at-rest alpha when no zone is hovered and not at boundary', () => {
+      const counter = createTestCounter({ meta: { currentValue: 5 } });
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: null, clampFlash: false },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      const minus = getGlyphByLabel(container, 'counter-minus-glyph');
+      const plus = getGlyphByLabel(container, 'counter-plus-glyph');
+      expect(minus?.alpha).toBeCloseTo(0.55, 5);
+      expect(plus?.alpha).toBeCloseTo(0.55, 5);
+      // No tint child either.
+      expect(
+        getChildByLabel(container, 'counter-minus-zone-tint'),
+      ).toBeUndefined();
+      expect(
+        getChildByLabel(container, 'counter-plus-zone-tint'),
+      ).toBeUndefined();
+    });
+
+    it('raises the hovered side glyph to full opacity and adds a tint overlay', () => {
+      const counter = createTestCounter({ meta: { currentValue: 5 } });
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: 'plus', clampFlash: false },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      const plus = getGlyphByLabel(container, 'counter-plus-glyph');
+      expect(plus?.alpha).toBe(1.0);
+      // Tint overlay is present for the hovered zone, not the other.
+      expect(
+        getChildByLabel(container, 'counter-plus-zone-tint'),
+      ).toBeDefined();
+      expect(
+        getChildByLabel(container, 'counter-minus-zone-tint'),
+      ).toBeUndefined();
+    });
+
+    it('drops the plus glyph alpha to the boundary value when at max and suppresses the hover tint', () => {
+      const counter = createTestCounter({
+        meta: { currentValue: 99, max: 99 },
+      });
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: 'plus', clampFlash: false },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      const plus = getGlyphByLabel(container, 'counter-plus-glyph');
+      expect(plus?.alpha).toBeCloseTo(0.25, 5);
+      // No tint when at the boundary — the zone is non-interactive.
+      expect(
+        getChildByLabel(container, 'counter-plus-zone-tint'),
+      ).toBeUndefined();
+    });
+
+    it('drops the minus glyph alpha to the boundary value when at min', () => {
+      const counter = createTestCounter({
+        meta: { currentValue: 0, min: 0 },
+      });
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: 'minus', clampFlash: false },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      const minus = getGlyphByLabel(container, 'counter-minus-glyph');
+      expect(minus?.alpha).toBeCloseTo(0.25, 5);
+      expect(
+        getChildByLabel(container, 'counter-minus-zone-tint'),
+      ).toBeUndefined();
+    });
+
+    it('renders the clamp-flash overlay when counterZoneState.clampFlash is true', () => {
+      const counter = createTestCounter({
+        meta: { currentValue: 99, max: 99 },
+      });
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: 'plus', clampFlash: true },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      expect(getChildByLabel(container, 'counter-clamp-flash')).toBeDefined();
+    });
+
+    it('omits the clamp-flash overlay when clampFlash is false', () => {
+      const counter = createTestCounter();
+      const ctx: RenderContext = {
+        ...mockContext,
+        counterZoneState: { hoveredZone: null, clampFlash: false },
+      };
+      const container = CounterBehaviors.render(counter, ctx);
+      expect(getChildByLabel(container, 'counter-clamp-flash')).toBeUndefined();
+    });
   });
 });

--- a/app/src/renderer/objects/counter/behaviors.ts
+++ b/app/src/renderer/objects/counter/behaviors.ts
@@ -4,6 +4,8 @@ import type { ObjectBehaviors, RenderContext, ShadowConfig } from '../types';
 import {
   COUNTER_BORDER_COLOR_NORMAL,
   COUNTER_BORDER_COLOR_SELECTED,
+  COUNTER_CLAMP_FLASH_ALPHA,
+  COUNTER_CLAMP_FLASH_COLOR,
   COUNTER_LABEL_ALPHA,
   COUNTER_LABEL_FONT_SIZE,
   COUNTER_LABEL_TEXT_COLOR,
@@ -13,23 +15,40 @@ import {
   COUNTER_VALUE_STROKE_WIDTH,
   COUNTER_VALUE_TEXT_COLOR,
   COUNTER_ZONE_GLYPH_ALPHA,
+  COUNTER_ZONE_GLYPH_ALPHA_ACTIVE,
+  COUNTER_ZONE_GLYPH_ALPHA_BOUNDARY,
   COUNTER_ZONE_GLYPH_COLOR,
   COUNTER_ZONE_GLYPH_FONT_SIZE,
+  COUNTER_ZONE_HOVER_TINT_ALPHA,
+  COUNTER_ZONE_HOVER_TINT_COLOR,
 } from './constants';
 import {
   getCounterColor,
   getCounterCurrentValue,
   getCounterDimensions,
+  getCounterMax,
+  getCounterMin,
   getCounterText,
 } from './utils';
 
 /**
- * Counter render (ct-yxh): horizontal rounded-rectangle pill with three
- * conceptual zones — left third minus, center third value, right third plus.
+ * Counter render (ct-yxh + ct-d2p): horizontal rounded-rectangle pill with
+ * three conceptual zones — left third minus, center third value, right
+ * third plus.
  *
- * The +/- glyphs are rendered at moderate opacity as visual affordances
- * only; event wiring (clicks/taps to mutate `currentValue`) is the next
- * bead (ct-d2p).
+ * Event wiring (ct-d2p) lives in the pointer pipeline, not in a per-object
+ * Pixi event handler — the pill renders as a single hit target and the
+ * pointer handler classifies the zone from world coordinates. This render
+ * function consumes `ctx.counterZoneState` to drive the state-aware
+ * visuals:
+ *
+ *   - Hovered side zone: glyph alpha 1.0 + faint white tint over the zone.
+ *   - At-rest side zone: glyph alpha ~0.55, no tint.
+ *   - Boundary side zone (plus at max, minus at min): alpha 0.25, no
+ *     hover response. The pointer pipeline also suppresses interaction.
+ *   - Clamp flash: when a boundary tap occurs, a brief white overlay
+ *     covers the pill body. Set by VisualManager for ~100ms then cleared.
+ *     Body color is preserved (no body recolor).
  *
  * Coordinate system: visuals are centered at the object's `_pos`. World
  * coordinates inside this render run from `-WIDTH/2 .. +WIDTH/2` on x and
@@ -41,6 +60,10 @@ export const CounterBehaviors: ObjectBehaviors = {
     const container = new Container();
     const { width, height } = getCounterDimensions(obj);
     const color = getCounterColor(obj);
+    const zoneState = ctx.counterZoneState ?? null;
+    const currentValue = getCounterCurrentValue(obj);
+    const atMin = currentValue <= getCounterMin(obj);
+    const atMax = currentValue >= getCounterMax(obj);
 
     // Pill body: rounded rectangle fill + border
     const body = new Graphics();
@@ -65,8 +88,44 @@ export const CounterBehaviors: ObjectBehaviors = {
     }
 
     const zoneCenterX = width / 3; // distance from center to side-zone center
+    const thirdWidth = width / 3;
 
-    // Minus glyph (left zone, decorative only — no event wiring in this bead)
+    // Hover tint behind each side zone — kept clipped to the third's
+    // rectangle (not rounded) so the visible edge is the pill's own border.
+    // Drawn before glyphs so glyphs sit on top.
+    if (zoneState?.hoveredZone === 'minus' && !atMin) {
+      const tint = new Graphics();
+      tint.rect(-width / 2, -height / 2, thirdWidth, height);
+      tint.fill({
+        color: COUNTER_ZONE_HOVER_TINT_COLOR,
+        alpha: COUNTER_ZONE_HOVER_TINT_ALPHA,
+      });
+      tint.label = 'counter-minus-zone-tint';
+      container.addChild(tint);
+    } else if (zoneState?.hoveredZone === 'plus' && !atMax) {
+      const tint = new Graphics();
+      tint.rect(width / 2 - thirdWidth, -height / 2, thirdWidth, height);
+      tint.fill({
+        color: COUNTER_ZONE_HOVER_TINT_COLOR,
+        alpha: COUNTER_ZONE_HOVER_TINT_ALPHA,
+      });
+      tint.label = 'counter-plus-zone-tint';
+      container.addChild(tint);
+    }
+
+    // Resolve per-zone alpha. Boundary > active > at-rest.
+    const minusAlpha = atMin
+      ? COUNTER_ZONE_GLYPH_ALPHA_BOUNDARY
+      : zoneState?.hoveredZone === 'minus'
+        ? COUNTER_ZONE_GLYPH_ALPHA_ACTIVE
+        : COUNTER_ZONE_GLYPH_ALPHA;
+    const plusAlpha = atMax
+      ? COUNTER_ZONE_GLYPH_ALPHA_BOUNDARY
+      : zoneState?.hoveredZone === 'plus'
+        ? COUNTER_ZONE_GLYPH_ALPHA_ACTIVE
+        : COUNTER_ZONE_GLYPH_ALPHA;
+
+    // Minus glyph (left zone)
     const minusGlyph = ctx.createText({
       text: '−', // Unicode MINUS SIGN — wider and visually balanced vs ASCII '-'
       style: {
@@ -78,10 +137,10 @@ export const CounterBehaviors: ObjectBehaviors = {
     minusGlyph.label = 'counter-minus-glyph';
     minusGlyph.anchor.set(0.5, 0.5);
     minusGlyph.position.set(-zoneCenterX, 0);
-    minusGlyph.alpha = COUNTER_ZONE_GLYPH_ALPHA;
+    minusGlyph.alpha = minusAlpha;
     container.addChild(minusGlyph);
 
-    // Plus glyph (right zone, decorative only — no event wiring in this bead)
+    // Plus glyph (right zone)
     const plusGlyph = ctx.createText({
       text: '+',
       style: {
@@ -93,12 +152,11 @@ export const CounterBehaviors: ObjectBehaviors = {
     plusGlyph.label = 'counter-plus-glyph';
     plusGlyph.anchor.set(0.5, 0.5);
     plusGlyph.position.set(zoneCenterX, 0);
-    plusGlyph.alpha = COUNTER_ZONE_GLYPH_ALPHA;
+    plusGlyph.alpha = plusAlpha;
     container.addChild(plusGlyph);
 
     // Current value (center zone) — mirrors the stack count badge text style:
     // large bold white with a dark stroke for legibility against any fill.
-    const currentValue = getCounterCurrentValue(obj);
     const valueText = ctx.createText({
       text: currentValue.toString(),
       style: {
@@ -133,6 +191,26 @@ export const CounterBehaviors: ObjectBehaviors = {
       label.position.set(-width / 6 + 1, -height / 2 + 3);
       label.alpha = COUNTER_LABEL_ALPHA;
       container.addChild(label);
+    }
+
+    // Clamp-flash overlay (ct-d2p) — sits on top of every other layer so
+    // it briefly washes the entire pill. Drawn with the same rounded-rect
+    // geometry as the body so it follows the pill silhouette.
+    if (zoneState?.clampFlash) {
+      const flash = new Graphics();
+      flash.roundRect(
+        -width / 2,
+        -height / 2,
+        width,
+        height,
+        COUNTER_PILL_BORDER_RADIUS,
+      );
+      flash.fill({
+        color: COUNTER_CLAMP_FLASH_COLOR,
+        alpha: COUNTER_CLAMP_FLASH_ALPHA,
+      });
+      flash.label = 'counter-clamp-flash';
+      container.addChild(flash);
     }
 
     return container;

--- a/app/src/renderer/objects/counter/behaviors.ts
+++ b/app/src/renderer/objects/counter/behaviors.ts
@@ -8,8 +8,10 @@ import {
   COUNTER_CLAMP_FLASH_COLOR,
   COUNTER_LABEL_ALPHA,
   COUNTER_LABEL_FONT_SIZE,
+  COUNTER_LABEL_STRIP_HEIGHT,
   COUNTER_LABEL_TEXT_COLOR,
   COUNTER_PILL_BORDER_RADIUS,
+  COUNTER_PILL_HEIGHT,
   COUNTER_VALUE_FONT_SIZE,
   COUNTER_VALUE_STROKE_COLOR,
   COUNTER_VALUE_STROKE_WIDTH,
@@ -26,9 +28,11 @@ import {
   getCounterColor,
   getCounterCurrentValue,
   getCounterDimensions,
+  getCounterInteractiveCenterY,
   getCounterMax,
   getCounterMin,
   getCounterText,
+  hasCounterLabel,
 } from './utils';
 
 /**
@@ -65,6 +69,14 @@ export const CounterBehaviors: ObjectBehaviors = {
     const atMin = currentValue <= getCounterMin(obj);
     const atMax = currentValue >= getCounterMax(obj);
 
+    // Interactive (bottom) region geometry (ct-ep4). The pill grows when a
+    // label is present so the label has its own top strip; +/- glyphs,
+    // value text, and hover/clamp visuals are anchored to the bottom
+    // (original-height) region instead of the geometric pill center.
+    const interactiveCenterY = getCounterInteractiveCenterY(obj);
+    const interactiveHeight = COUNTER_PILL_HEIGHT;
+    const interactiveTop = interactiveCenterY - interactiveHeight / 2;
+
     // Pill body: rounded rectangle fill + border
     const body = new Graphics();
     body.roundRect(
@@ -90,26 +102,41 @@ export const CounterBehaviors: ObjectBehaviors = {
     const zoneCenterX = width / 3; // distance from center to side-zone center
     const thirdWidth = width / 3;
 
-    // Hover tint behind each side zone — kept clipped to the third's
-    // rectangle (not rounded) so the visible edge is the pill's own border.
-    // Drawn before glyphs so glyphs sit on top.
-    if (zoneState?.hoveredZone === 'minus' && !atMin) {
+    // Hover tint behind each side zone. The tint Graphics draws a flat
+    // per-third rect over the interactive (bottom) region only, then a
+    // roundRect mask clones the pill silhouette so the visible tint
+    // never extends past the pill's rounded corners (ct-ep4). Drawn
+    // before glyphs so glyphs sit on top.
+    if (
+      (zoneState?.hoveredZone === 'minus' && !atMin) ||
+      (zoneState?.hoveredZone === 'plus' && !atMax)
+    ) {
+      const isMinus = zoneState?.hoveredZone === 'minus';
       const tint = new Graphics();
-      tint.rect(-width / 2, -height / 2, thirdWidth, height);
+      const tintX = isMinus ? -width / 2 : width / 2 - thirdWidth;
+      tint.rect(tintX, interactiveTop, thirdWidth, interactiveHeight);
       tint.fill({
         color: COUNTER_ZONE_HOVER_TINT_COLOR,
         alpha: COUNTER_ZONE_HOVER_TINT_ALPHA,
       });
-      tint.label = 'counter-minus-zone-tint';
-      container.addChild(tint);
-    } else if (zoneState?.hoveredZone === 'plus' && !atMax) {
-      const tint = new Graphics();
-      tint.rect(width / 2 - thirdWidth, -height / 2, thirdWidth, height);
-      tint.fill({
-        color: COUNTER_ZONE_HOVER_TINT_COLOR,
-        alpha: COUNTER_ZONE_HOVER_TINT_ALPHA,
-      });
-      tint.label = 'counter-plus-zone-tint';
+      tint.label = isMinus
+        ? 'counter-minus-zone-tint'
+        : 'counter-plus-zone-tint';
+
+      // Mask: clone of the pill body's roundRect so the tint is clipped
+      // to the pill silhouette (no square corners poking past the pill).
+      const tintMask = new Graphics();
+      tintMask.roundRect(
+        -width / 2,
+        -height / 2,
+        width,
+        height,
+        COUNTER_PILL_BORDER_RADIUS,
+      );
+      tintMask.fill(0xffffff);
+      tintMask.label = 'counter-zone-tint-mask';
+      container.addChild(tintMask);
+      tint.mask = tintMask;
       container.addChild(tint);
     }
 
@@ -125,7 +152,7 @@ export const CounterBehaviors: ObjectBehaviors = {
         ? COUNTER_ZONE_GLYPH_ALPHA_ACTIVE
         : COUNTER_ZONE_GLYPH_ALPHA;
 
-    // Minus glyph (left zone)
+    // Minus glyph (left zone) — centered in the interactive bottom region.
     const minusGlyph = ctx.createText({
       text: '−', // Unicode MINUS SIGN — wider and visually balanced vs ASCII '-'
       style: {
@@ -136,11 +163,11 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     minusGlyph.label = 'counter-minus-glyph';
     minusGlyph.anchor.set(0.5, 0.5);
-    minusGlyph.position.set(-zoneCenterX, 0);
+    minusGlyph.position.set(-zoneCenterX, interactiveCenterY);
     minusGlyph.alpha = minusAlpha;
     container.addChild(minusGlyph);
 
-    // Plus glyph (right zone)
+    // Plus glyph (right zone) — centered in the interactive bottom region.
     const plusGlyph = ctx.createText({
       text: '+',
       style: {
@@ -151,12 +178,14 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     plusGlyph.label = 'counter-plus-glyph';
     plusGlyph.anchor.set(0.5, 0.5);
-    plusGlyph.position.set(zoneCenterX, 0);
+    plusGlyph.position.set(zoneCenterX, interactiveCenterY);
     plusGlyph.alpha = plusAlpha;
     container.addChild(plusGlyph);
 
     // Current value (center zone) — mirrors the stack count badge text style:
     // large bold white with a dark stroke for legibility against any fill.
+    // Centered in the interactive bottom region rather than the pill's
+    // geometric center so a label strip above doesn't shift the value.
     const valueText = ctx.createText({
       text: currentValue.toString(),
       style: {
@@ -171,15 +200,19 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     valueText.label = 'counter-value';
     valueText.anchor.set(0.5, 0.5);
-    valueText.position.set(0, 0);
+    valueText.position.set(0, interactiveCenterY);
     container.addChild(valueText);
 
-    // Optional label (`text`): small, semi-opaque, top-left of center zone.
-    // Bounds of the center zone in local space: x in [-width/6, +width/6].
-    const labelText = getCounterText(obj);
-    if (labelText !== undefined && labelText.length > 0) {
+    // Optional label (`text`): rendered INSIDE a dedicated top strip of
+    // the pill (ct-ep4). When a label is present the pill grows by
+    // `COUNTER_LABEL_STRIP_HEIGHT` so this band exists; the label is
+    // anchored center-top of the strip and sits inside the pill
+    // silhouette rather than floating above it.
+    if (hasCounterLabel(obj)) {
+      const labelText = getCounterText(obj);
       const label = ctx.createText({
-        text: labelText,
+        // hasCounterLabel guarantees this is defined and non-empty.
+        text: labelText ?? '',
         style: {
           fontSize: COUNTER_LABEL_FONT_SIZE,
           fill: COUNTER_LABEL_TEXT_COLOR,
@@ -187,29 +220,39 @@ export const CounterBehaviors: ObjectBehaviors = {
         },
       });
       label.label = 'counter-label';
-      label.anchor.set(0, 0); // top-left
-      label.position.set(-width / 6 + 1, -height / 2 + 3);
+      // Center the label vertically inside the top strip. Strip spans
+      // local-y in [-height/2, -height/2 + COUNTER_LABEL_STRIP_HEIGHT].
+      label.anchor.set(0.5, 0.5);
+      label.position.set(0, -height / 2 + COUNTER_LABEL_STRIP_HEIGHT / 2);
       label.alpha = COUNTER_LABEL_ALPHA;
       container.addChild(label);
     }
 
     // Clamp-flash overlay (ct-d2p) — sits on top of every other layer so
-    // it briefly washes the entire pill. Drawn with the same rounded-rect
-    // geometry as the body so it follows the pill silhouette.
+    // it briefly washes the interactive region. Bounded to the bottom
+    // region with the pill-silhouette mask so the label strip stays
+    // unaffected (ct-ep4).
     if (zoneState?.clampFlash) {
       const flash = new Graphics();
-      flash.roundRect(
+      flash.rect(-width / 2, interactiveTop, width, interactiveHeight);
+      flash.fill({
+        color: COUNTER_CLAMP_FLASH_COLOR,
+        alpha: COUNTER_CLAMP_FLASH_ALPHA,
+      });
+      flash.label = 'counter-clamp-flash';
+
+      const flashMask = new Graphics();
+      flashMask.roundRect(
         -width / 2,
         -height / 2,
         width,
         height,
         COUNTER_PILL_BORDER_RADIUS,
       );
-      flash.fill({
-        color: COUNTER_CLAMP_FLASH_COLOR,
-        alpha: COUNTER_CLAMP_FLASH_ALPHA,
-      });
-      flash.label = 'counter-clamp-flash';
+      flashMask.fill(0xffffff);
+      flashMask.label = 'counter-clamp-flash-mask';
+      container.addChild(flashMask);
+      flash.mask = flashMask;
       container.addChild(flash);
     }
 

--- a/app/src/renderer/objects/counter/behaviors.ts
+++ b/app/src/renderer/objects/counter/behaviors.ts
@@ -40,11 +40,14 @@ import {
  * pill with three conceptual zones — left third minus, center third value,
  * right third plus.
  *
- * The labeled and unlabeled counters are one component family in two
- * states (ct-bmk): same pill silhouette, same fill, same border, same
- * +/- treatment. When a `text` label is present the pill grows slightly
- * (by COUNTER_LABEL_HEIGHT_BUMP) and the center stacks two text lines —
- * a small bold label on top, a slightly-smaller numeric value below.
+ * The labeled and unlabeled counters share one fixed silhouette (ct-bmk):
+ * the pill is always COUNTER_PILL_WIDTH x COUNTER_PILL_HEIGHT (90x44) in
+ * both states — same fill, same border, same +/- treatment. The ONLY
+ * difference is the text layout inside: bare counters render the value
+ * centered at y=0 in the larger font; labeled counters stack a small
+ * bold label on top (COUNTER_LABEL_LINE_Y) and a slightly-smaller numeric
+ * value below (COUNTER_VALUE_LINE_Y_LABELED), both fitting inside the
+ * same 44px pill height.
  *
  * Event wiring (ct-d2p) lives in the pointer pipeline, not in a per-object
  * Pixi event handler — the pill renders as a single hit target and the
@@ -152,8 +155,8 @@ export const CounterBehaviors: ObjectBehaviors = {
         : COUNTER_ZONE_GLYPH_ALPHA;
 
     // +/- glyphs sit centered vertically on the pill in both states. The
-    // pill grows by only a few pixels in the labeled state, so a single
-    // centered y=0 works for both — no per-state offset needed.
+    // pill height is fixed (ct-bmk) so a single centered y=0 works for
+    // both labeled and bare — no per-state offset needed.
     const minusGlyph = ctx.createText({
       text: '−', // Unicode MINUS SIGN — wider and visually balanced vs ASCII '-'
       style: {

--- a/app/src/renderer/objects/counter/behaviors.ts
+++ b/app/src/renderer/objects/counter/behaviors.ts
@@ -8,11 +8,12 @@ import {
   COUNTER_CLAMP_FLASH_COLOR,
   COUNTER_LABEL_ALPHA,
   COUNTER_LABEL_FONT_SIZE,
-  COUNTER_LABEL_STRIP_HEIGHT,
+  COUNTER_LABEL_LINE_Y,
   COUNTER_LABEL_TEXT_COLOR,
   COUNTER_PILL_BORDER_RADIUS,
-  COUNTER_PILL_HEIGHT,
   COUNTER_VALUE_FONT_SIZE,
+  COUNTER_VALUE_FONT_SIZE_LABELED,
+  COUNTER_VALUE_LINE_Y_LABELED,
   COUNTER_VALUE_STROKE_COLOR,
   COUNTER_VALUE_STROKE_WIDTH,
   COUNTER_VALUE_TEXT_COLOR,
@@ -28,7 +29,6 @@ import {
   getCounterColor,
   getCounterCurrentValue,
   getCounterDimensions,
-  getCounterInteractiveCenterY,
   getCounterMax,
   getCounterMin,
   getCounterText,
@@ -36,9 +36,15 @@ import {
 } from './utils';
 
 /**
- * Counter render (ct-yxh + ct-d2p): horizontal rounded-rectangle pill with
- * three conceptual zones — left third minus, center third value, right
- * third plus.
+ * Counter render (ct-yxh + ct-d2p + ct-bmk): horizontal rounded-rectangle
+ * pill with three conceptual zones — left third minus, center third value,
+ * right third plus.
+ *
+ * The labeled and unlabeled counters are one component family in two
+ * states (ct-bmk): same pill silhouette, same fill, same border, same
+ * +/- treatment. When a `text` label is present the pill grows slightly
+ * (by COUNTER_LABEL_HEIGHT_BUMP) and the center stacks two text lines —
+ * a small bold label on top, a slightly-smaller numeric value below.
  *
  * Event wiring (ct-d2p) lives in the pointer pipeline, not in a per-object
  * Pixi event handler — the pill renders as a single hit target and the
@@ -46,7 +52,8 @@ import {
  * function consumes `ctx.counterZoneState` to drive the state-aware
  * visuals:
  *
- *   - Hovered side zone: glyph alpha 1.0 + faint white tint over the zone.
+ *   - Hovered side zone: glyph alpha 1.0 + faint white tint over the zone,
+ *     clipped to the pill silhouette via a roundRect mask (ct-ep4).
  *   - At-rest side zone: glyph alpha ~0.55, no tint.
  *   - Boundary side zone (plus at max, minus at min): alpha 0.25, no
  *     hover response. The pointer pipeline also suppresses interaction.
@@ -54,10 +61,9 @@ import {
  *     covers the pill body. Set by VisualManager for ~100ms then cleared.
  *     Body color is preserved (no body recolor).
  *
- * Coordinate system: visuals are centered at the object's `_pos`. World
- * coordinates inside this render run from `-WIDTH/2 .. +WIDTH/2` on x and
- * `-HEIGHT/2 .. +HEIGHT/2` on y. Zone centers fall at `-WIDTH/3`, `0`,
- * `+WIDTH/3`.
+ * Coordinate system: visuals are centered at the object's `_pos`. Local
+ * coordinates run from `-WIDTH/2 .. +WIDTH/2` on x and `-HEIGHT/2 ..
+ * +HEIGHT/2` on y. Zone centers fall at `-WIDTH/3`, `0`, `+WIDTH/3`.
  */
 export const CounterBehaviors: ObjectBehaviors = {
   render(obj: TableObject, ctx: RenderContext): Container {
@@ -68,14 +74,7 @@ export const CounterBehaviors: ObjectBehaviors = {
     const currentValue = getCounterCurrentValue(obj);
     const atMin = currentValue <= getCounterMin(obj);
     const atMax = currentValue >= getCounterMax(obj);
-
-    // Interactive (bottom) region geometry (ct-ep4). The pill grows when a
-    // label is present so the label has its own top strip; +/- glyphs,
-    // value text, and hover/clamp visuals are anchored to the bottom
-    // (original-height) region instead of the geometric pill center.
-    const interactiveCenterY = getCounterInteractiveCenterY(obj);
-    const interactiveHeight = COUNTER_PILL_HEIGHT;
-    const interactiveTop = interactiveCenterY - interactiveHeight / 2;
+    const labeled = hasCounterLabel(obj);
 
     // Pill body: rounded rectangle fill + border
     const body = new Graphics();
@@ -103,10 +102,10 @@ export const CounterBehaviors: ObjectBehaviors = {
     const thirdWidth = width / 3;
 
     // Hover tint behind each side zone. The tint Graphics draws a flat
-    // per-third rect over the interactive (bottom) region only, then a
-    // roundRect mask clones the pill silhouette so the visible tint
-    // never extends past the pill's rounded corners (ct-ep4). Drawn
-    // before glyphs so glyphs sit on top.
+    // per-third rect over the full pill height, then a roundRect mask
+    // clones the pill silhouette so the visible tint never extends past
+    // the pill's rounded corners (ct-ep4). Drawn before glyphs so glyphs
+    // sit on top.
     if (
       (zoneState?.hoveredZone === 'minus' && !atMin) ||
       (zoneState?.hoveredZone === 'plus' && !atMax)
@@ -114,7 +113,7 @@ export const CounterBehaviors: ObjectBehaviors = {
       const isMinus = zoneState?.hoveredZone === 'minus';
       const tint = new Graphics();
       const tintX = isMinus ? -width / 2 : width / 2 - thirdWidth;
-      tint.rect(tintX, interactiveTop, thirdWidth, interactiveHeight);
+      tint.rect(tintX, -height / 2, thirdWidth, height);
       tint.fill({
         color: COUNTER_ZONE_HOVER_TINT_COLOR,
         alpha: COUNTER_ZONE_HOVER_TINT_ALPHA,
@@ -152,7 +151,9 @@ export const CounterBehaviors: ObjectBehaviors = {
         ? COUNTER_ZONE_GLYPH_ALPHA_ACTIVE
         : COUNTER_ZONE_GLYPH_ALPHA;
 
-    // Minus glyph (left zone) — centered in the interactive bottom region.
+    // +/- glyphs sit centered vertically on the pill in both states. The
+    // pill grows by only a few pixels in the labeled state, so a single
+    // centered y=0 works for both — no per-state offset needed.
     const minusGlyph = ctx.createText({
       text: '−', // Unicode MINUS SIGN — wider and visually balanced vs ASCII '-'
       style: {
@@ -163,11 +164,10 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     minusGlyph.label = 'counter-minus-glyph';
     minusGlyph.anchor.set(0.5, 0.5);
-    minusGlyph.position.set(-zoneCenterX, interactiveCenterY);
+    minusGlyph.position.set(-zoneCenterX, 0);
     minusGlyph.alpha = minusAlpha;
     container.addChild(minusGlyph);
 
-    // Plus glyph (right zone) — centered in the interactive bottom region.
     const plusGlyph = ctx.createText({
       text: '+',
       style: {
@@ -178,18 +178,21 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     plusGlyph.label = 'counter-plus-glyph';
     plusGlyph.anchor.set(0.5, 0.5);
-    plusGlyph.position.set(zoneCenterX, interactiveCenterY);
+    plusGlyph.position.set(zoneCenterX, 0);
     plusGlyph.alpha = plusAlpha;
     container.addChild(plusGlyph);
 
-    // Current value (center zone) — mirrors the stack count badge text style:
-    // large bold white with a dark stroke for legibility against any fill.
-    // Centered in the interactive bottom region rather than the pill's
-    // geometric center so a label strip above doesn't shift the value.
+    // Center value text — mirrors the stack count-badge style (white fill,
+    // dark stroke, bold). In the bare state it's the only center line and
+    // sits at y=0 with the larger font. In the labeled state it shrinks
+    // slightly and drops below center to make room for the label line
+    // above it.
     const valueText = ctx.createText({
       text: currentValue.toString(),
       style: {
-        fontSize: COUNTER_VALUE_FONT_SIZE,
+        fontSize: labeled
+          ? COUNTER_VALUE_FONT_SIZE_LABELED
+          : COUNTER_VALUE_FONT_SIZE,
         fill: COUNTER_VALUE_TEXT_COLOR,
         fontWeight: 'bold',
         stroke: {
@@ -200,15 +203,13 @@ export const CounterBehaviors: ObjectBehaviors = {
     });
     valueText.label = 'counter-value';
     valueText.anchor.set(0.5, 0.5);
-    valueText.position.set(0, interactiveCenterY);
+    valueText.position.set(0, labeled ? COUNTER_VALUE_LINE_Y_LABELED : 0);
     container.addChild(valueText);
 
-    // Optional label (`text`): rendered INSIDE a dedicated top strip of
-    // the pill (ct-ep4). When a label is present the pill grows by
-    // `COUNTER_LABEL_STRIP_HEIGHT` so this band exists; the label is
-    // anchored center-top of the strip and sits inside the pill
-    // silhouette rather than floating above it.
-    if (hasCounterLabel(obj)) {
+    // Optional label (`text`): small bold line above the value, inside the
+    // same pill silhouette (ct-bmk). No separate visual band — the label
+    // is just the upper of two stacked text lines.
+    if (labeled) {
       const labelText = getCounterText(obj);
       const label = ctx.createText({
         // hasCounterLabel guarantees this is defined and non-empty.
@@ -220,21 +221,18 @@ export const CounterBehaviors: ObjectBehaviors = {
         },
       });
       label.label = 'counter-label';
-      // Center the label vertically inside the top strip. Strip spans
-      // local-y in [-height/2, -height/2 + COUNTER_LABEL_STRIP_HEIGHT].
       label.anchor.set(0.5, 0.5);
-      label.position.set(0, -height / 2 + COUNTER_LABEL_STRIP_HEIGHT / 2);
+      label.position.set(0, COUNTER_LABEL_LINE_Y);
       label.alpha = COUNTER_LABEL_ALPHA;
       container.addChild(label);
     }
 
     // Clamp-flash overlay (ct-d2p) — sits on top of every other layer so
-    // it briefly washes the interactive region. Bounded to the bottom
-    // region with the pill-silhouette mask so the label strip stays
-    // unaffected (ct-ep4).
+    // it briefly washes the pill. Clipped to the pill silhouette so flat
+    // corners don't poke past the rounded border (ct-ep4).
     if (zoneState?.clampFlash) {
       const flash = new Graphics();
-      flash.rect(-width / 2, interactiveTop, width, interactiveHeight);
+      flash.rect(-width / 2, -height / 2, width, height);
       flash.fill({
         color: COUNTER_CLAMP_FLASH_COLOR,
         alpha: COUNTER_CLAMP_FLASH_ALPHA,

--- a/app/src/renderer/objects/counter/constants.ts
+++ b/app/src/renderer/objects/counter/constants.ts
@@ -60,10 +60,23 @@ export const COUNTER_CLAMP_FLASH_COLOR = 0xffffff;
 export const COUNTER_CLAMP_FLASH_ALPHA = 0.45;
 export const COUNTER_CLAMP_FLASH_DURATION_MS = 100;
 
-/** Label (`text`) styling — small, semi-opaque, top-left of center zone. */
-export const COUNTER_LABEL_FONT_SIZE = 10;
+/**
+ * Label (`text`) styling — rendered inside a dedicated top strip at the
+ * top of the pill (ct-ep4). When a counter has a `text` value the pill
+ * grows by `COUNTER_LABEL_STRIP_HEIGHT` so the label has its own
+ * horizontal band above the value/glyph row, never competing for the
+ * tight center zone occupied by the numeric value.
+ */
+export const COUNTER_LABEL_FONT_SIZE = 11;
 export const COUNTER_LABEL_TEXT_COLOR = 0xffffff;
-export const COUNTER_LABEL_ALPHA = 0.6;
+export const COUNTER_LABEL_ALPHA = 0.85;
+/**
+ * Extra height added to the pill when a label is present. The pill stays a
+ * single rounded-rect silhouette; the strip is the top portion of that
+ * silhouette where the label is rendered. Side-zone (+/-) hit-tests still
+ * map only to the interactive bottom region (the original pill height).
+ */
+export const COUNTER_LABEL_STRIP_HEIGHT = 16;
 
 // ============================================================================
 // CounterMeta defaults (template + instance model)

--- a/app/src/renderer/objects/counter/constants.ts
+++ b/app/src/renderer/objects/counter/constants.ts
@@ -66,30 +66,23 @@ export const COUNTER_CLAMP_FLASH_DURATION_MS = 100;
 
 /**
  * Label (`text`) styling — rendered as a small bold line ABOVE the value
- * line, inside the same pill silhouette (ct-bmk). When a counter has a
- * `text` value the pill grows by `COUNTER_LABEL_HEIGHT_BUMP` so two lines
- * of text fit comfortably, with the small label on top and the (slightly
- * smaller) numeric value below. The bare and labeled counters share one
- * pill silhouette — same fill color, same border, same +/- treatment.
+ * line, inside the same pill silhouette (ct-bmk). The pill dimensions are
+ * IDENTICAL in the bare and labeled states (always 90x44); only the text
+ * layout inside varies. When a `text` value is set the center stacks two
+ * lines — a small bold label on top and a slightly-smaller numeric value
+ * below — both fitting inside the same 44px pill height.
  */
 export const COUNTER_LABEL_FONT_SIZE = 11;
 export const COUNTER_LABEL_TEXT_COLOR = 0xffffff;
 export const COUNTER_LABEL_ALPHA = 0.95;
 /**
- * Extra height added to the pill when a label is present. Just enough to
- * fit the small label line above the (slightly-shrunk) numeric value
- * without crowding either line. The pill stays a single rounded-rect
- * silhouette; +/- hit-tests cover the full pill, not a sub-region.
- */
-export const COUNTER_LABEL_HEIGHT_BUMP = 6;
-/**
  * Vertical positions (local-y inside the pill) of the two text lines in
- * the labeled state. The label sits slightly above center; the value sits
- * slightly below. Tuned so both feel comfortably padded inside the taller
- * pill silhouette.
+ * the labeled state. The label sits in the top half; the value sits in
+ * the bottom half. Tuned by eye so both lines fit comfortably inside the
+ * fixed 44px pill height (-22 .. +22 local-y) without crowding.
  */
-export const COUNTER_LABEL_LINE_Y = -8;
-export const COUNTER_VALUE_LINE_Y_LABELED = 6;
+export const COUNTER_LABEL_LINE_Y = -11;
+export const COUNTER_VALUE_LINE_Y_LABELED = 7;
 
 // ============================================================================
 // CounterMeta defaults (template + instance model)

--- a/app/src/renderer/objects/counter/constants.ts
+++ b/app/src/renderer/objects/counter/constants.ts
@@ -30,10 +30,35 @@ export const COUNTER_VALUE_TEXT_COLOR = 0xffffff;
 export const COUNTER_VALUE_STROKE_COLOR = 0x000000;
 export const COUNTER_VALUE_STROKE_WIDTH = 3;
 
-/** +/- glyph styling (visual only in this bead; ct-d2p wires events). */
+/** +/- glyph styling. Event wiring lands in ct-d2p. */
 export const COUNTER_ZONE_GLYPH_FONT_SIZE = 24;
 export const COUNTER_ZONE_GLYPH_COLOR = 0xffffff;
+/** Glyph alpha at rest (no hover, value not at boundary). */
 export const COUNTER_ZONE_GLYPH_ALPHA = 0.55;
+/** Glyph alpha while the side zone is hovered or actively pressed. */
+export const COUNTER_ZONE_GLYPH_ALPHA_ACTIVE = 1.0;
+/**
+ * Glyph alpha when the corresponding boundary is reached (plus at max,
+ * minus at min). The zone stops responding to taps in this state.
+ */
+export const COUNTER_ZONE_GLYPH_ALPHA_BOUNDARY = 0.25;
+
+/**
+ * Tint overlay drawn behind the +/- glyph when its zone is hovered (ct-d2p).
+ * A low-alpha white overlay sits on top of the pill body, brightening the
+ * relevant third of the pill without changing the body color.
+ */
+export const COUNTER_ZONE_HOVER_TINT_COLOR = 0xffffff;
+export const COUNTER_ZONE_HOVER_TINT_ALPHA = 0.18;
+
+/**
+ * Pill-body clamp-flash overlay (ct-d2p). When a +/- tap hits a boundary,
+ * the body is briefly washed with this color to signal "blocked", then
+ * cleared. The body's underlying color is preserved (no recolor).
+ */
+export const COUNTER_CLAMP_FLASH_COLOR = 0xffffff;
+export const COUNTER_CLAMP_FLASH_ALPHA = 0.45;
+export const COUNTER_CLAMP_FLASH_DURATION_MS = 100;
 
 /** Label (`text`) styling — small, semi-opaque, top-left of center zone. */
 export const COUNTER_LABEL_FONT_SIZE = 10;

--- a/app/src/renderer/objects/counter/constants.ts
+++ b/app/src/renderer/objects/counter/constants.ts
@@ -23,9 +23,13 @@ export const COUNTER_BORDER_COLOR_SELECTED = 0xef4444; // Red
 /**
  * Value text styling. Mirrors the stack count-badge text style (white fill,
  * dark stroke, bold) so the counter value reads as the same kind of
- * affordance as a stack's count.
+ * affordance as a stack's count. Bare (unlabeled) counters use
+ * `COUNTER_VALUE_FONT_SIZE`; labeled counters use the smaller
+ * `COUNTER_VALUE_FONT_SIZE_LABELED` so the small label line above can fit
+ * inside a pill of nearly the same height.
  */
 export const COUNTER_VALUE_FONT_SIZE = 22;
+export const COUNTER_VALUE_FONT_SIZE_LABELED = 18;
 export const COUNTER_VALUE_TEXT_COLOR = 0xffffff;
 export const COUNTER_VALUE_STROKE_COLOR = 0x000000;
 export const COUNTER_VALUE_STROKE_WIDTH = 3;
@@ -61,22 +65,31 @@ export const COUNTER_CLAMP_FLASH_ALPHA = 0.45;
 export const COUNTER_CLAMP_FLASH_DURATION_MS = 100;
 
 /**
- * Label (`text`) styling — rendered inside a dedicated top strip at the
- * top of the pill (ct-ep4). When a counter has a `text` value the pill
- * grows by `COUNTER_LABEL_STRIP_HEIGHT` so the label has its own
- * horizontal band above the value/glyph row, never competing for the
- * tight center zone occupied by the numeric value.
+ * Label (`text`) styling — rendered as a small bold line ABOVE the value
+ * line, inside the same pill silhouette (ct-bmk). When a counter has a
+ * `text` value the pill grows by `COUNTER_LABEL_HEIGHT_BUMP` so two lines
+ * of text fit comfortably, with the small label on top and the (slightly
+ * smaller) numeric value below. The bare and labeled counters share one
+ * pill silhouette — same fill color, same border, same +/- treatment.
  */
 export const COUNTER_LABEL_FONT_SIZE = 11;
 export const COUNTER_LABEL_TEXT_COLOR = 0xffffff;
-export const COUNTER_LABEL_ALPHA = 0.85;
+export const COUNTER_LABEL_ALPHA = 0.95;
 /**
- * Extra height added to the pill when a label is present. The pill stays a
- * single rounded-rect silhouette; the strip is the top portion of that
- * silhouette where the label is rendered. Side-zone (+/-) hit-tests still
- * map only to the interactive bottom region (the original pill height).
+ * Extra height added to the pill when a label is present. Just enough to
+ * fit the small label line above the (slightly-shrunk) numeric value
+ * without crowding either line. The pill stays a single rounded-rect
+ * silhouette; +/- hit-tests cover the full pill, not a sub-region.
  */
-export const COUNTER_LABEL_STRIP_HEIGHT = 16;
+export const COUNTER_LABEL_HEIGHT_BUMP = 6;
+/**
+ * Vertical positions (local-y inside the pill) of the two text lines in
+ * the labeled state. The label sits slightly above center; the value sits
+ * slightly below. Tuned so both feel comfortably padded inside the taller
+ * pill silhouette.
+ */
+export const COUNTER_LABEL_LINE_Y = -8;
+export const COUNTER_VALUE_LINE_Y_LABELED = 6;
 
 // ============================================================================
 // CounterMeta defaults (template + instance model)

--- a/app/src/renderer/objects/counter/utils.ts
+++ b/app/src/renderer/objects/counter/utils.ts
@@ -4,7 +4,7 @@ import {
   COUNTER_DEFAULT_MAX,
   COUNTER_DEFAULT_MIN,
   COUNTER_DEFAULT_STARTING_VALUE,
-  COUNTER_LABEL_STRIP_HEIGHT,
+  COUNTER_LABEL_HEIGHT_BUMP,
   COUNTER_PILL_HEIGHT,
   COUNTER_PILL_WIDTH,
   COUNTER_TYPE_GENERIC,
@@ -122,10 +122,12 @@ export function getCounterCurrentValue(obj: TableObject): number {
  *
  * Counters render as a horizontal rounded-rectangle pill (ct-yxh). The
  * width is fixed by `COUNTER_PILL_WIDTH`; the height is normally
- * `COUNTER_PILL_HEIGHT`, but grows by `COUNTER_LABEL_STRIP_HEIGHT` when
- * the counter carries a `text` label (ct-ep4). The added strip occupies
- * the top portion of the pill silhouette; the original height region
- * (the bottom portion) remains the interactive +/- zone.
+ * `COUNTER_PILL_HEIGHT`, but grows by `COUNTER_LABEL_HEIGHT_BUMP` when
+ * the counter carries a `text` label (ct-bmk) — just enough extra room
+ * for a small label line above the (slightly smaller) numeric value.
+ * The pill remains a single rounded-rect silhouette in both states; the
+ * entire pill is interactive for +/- hit-testing regardless of whether a
+ * label is present.
  */
 export function getCounterDimensions(obj: TableObject): {
   width: number;
@@ -135,34 +137,18 @@ export function getCounterDimensions(obj: TableObject): {
   return {
     width: COUNTER_PILL_WIDTH,
     height: hasLabel
-      ? COUNTER_PILL_HEIGHT + COUNTER_LABEL_STRIP_HEIGHT
+      ? COUNTER_PILL_HEIGHT + COUNTER_LABEL_HEIGHT_BUMP
       : COUNTER_PILL_HEIGHT,
   };
 }
 
 /**
  * Whether the counter has a non-empty `text` label. Drives the
- * label-strip extension of the pill height (ct-ep4).
+ * slight height bump on the pill (ct-bmk).
  */
 export function hasCounterLabel(obj: TableObject): boolean {
   const text = getCounterText(obj);
   return text !== undefined && text.length > 0;
-}
-
-/**
- * Vertical offset (in local pill coordinates) of the interactive
- * +/- region's center, relative to the pill's geometric center.
- *
- * Pill local-y spans [-height/2, +height/2]. When no label is present
- * the pill height equals `COUNTER_PILL_HEIGHT` and the interactive
- * region is the full pill — offset 0. When a label is present, the top
- * `COUNTER_LABEL_STRIP_HEIGHT` of the pill is reserved for the name and
- * the interactive region sits below it; its center is shifted down by
- * half the strip height so the value text/+/- glyphs land centered in
- * the bottom region rather than the geometric center.
- */
-export function getCounterInteractiveCenterY(obj: TableObject): number {
-  return hasCounterLabel(obj) ? COUNTER_LABEL_STRIP_HEIGHT / 2 : 0;
 }
 
 /**
@@ -208,19 +194,8 @@ export function counterZoneAtPoint(
     return null;
   }
 
-  // When a label strip is present (ct-ep4) only the interactive bottom
-  // region maps to +/- zones; the top strip is the label band. Hits in
-  // the strip itself fall through to `value` (no-op for taps) so taps on
-  // the label area don't accidentally increment/decrement.
-  const interactiveCenterY = getCounterInteractiveCenterY(obj);
-  const interactiveHalfH = COUNTER_PILL_HEIGHT / 2;
-  if (
-    localY < interactiveCenterY - interactiveHalfH ||
-    localY > interactiveCenterY + interactiveHalfH
-  ) {
-    return 'value';
-  }
-
+  // With the two-line stacked layout (ct-bmk) the entire pill is
+  // interactive for +/- — there's no reserved label strip to exclude.
   const third = width / 3;
   if (localX <= -halfW + third) return 'minus';
   if (localX >= halfW - third) return 'plus';

--- a/app/src/renderer/objects/counter/utils.ts
+++ b/app/src/renderer/objects/counter/utils.ts
@@ -130,3 +130,71 @@ export function getCounterDimensions(_obj: TableObject): {
 } {
   return { width: COUNTER_PILL_WIDTH, height: COUNTER_PILL_HEIGHT };
 }
+
+/**
+ * Sub-region of the Counter pill (ct-d2p). The pill is conceptually three
+ * horizontal thirds: minus / value / plus.
+ */
+export type CounterZoneHit = 'minus' | 'value' | 'plus';
+
+/**
+ * Hit-test a world-space point against a Counter's +/- zones (ct-d2p).
+ *
+ * Returns the zone the point falls into, or `null` if the point is
+ * outside the pill bounds entirely. The pill renders centered on
+ * `obj._pos` (see CounterBehaviors.render); zones are split at one-third
+ * and two-thirds of the pill width along the x-axis.
+ *
+ * Coordinates are transformed into the pill's local space first so that
+ * any future rotation (the counter's `_pos.r`) is respected; today the
+ * Counter is non-rotatable (canRotate: false in capabilities), but the
+ * local-coords transform is essentially free and avoids subtle bugs if
+ * that capability ever flips.
+ */
+export function counterZoneAtPoint(
+  worldX: number,
+  worldY: number,
+  obj: TableObject,
+): CounterZoneHit | null {
+  const { width, height } = getCounterDimensions(obj);
+
+  // Transform world point into the counter's local space.
+  const dx = worldX - obj._pos.x;
+  const dy = worldY - obj._pos.y;
+  const angleRad = (obj._pos.r * Math.PI) / 180;
+  const cos = Math.cos(-angleRad);
+  const sin = Math.sin(-angleRad);
+  const localX = dx * cos - dy * sin;
+  const localY = dx * sin + dy * cos;
+
+  // Point must be inside the pill's bounding rect to count as a zone hit.
+  const halfW = width / 2;
+  const halfH = height / 2;
+  if (localX < -halfW || localX > halfW || localY < -halfH || localY > halfH) {
+    return null;
+  }
+
+  const third = width / 3;
+  if (localX < -third / 2 + 0) {
+    // Strictly: left third spans [-halfW, -halfW + third] = [-halfW, -third/2].
+    // The two expressions are equivalent since halfW = 3 * third / 2.
+    // We use the centered split for readability.
+  }
+  if (localX <= -halfW + third) return 'minus';
+  if (localX >= halfW - third) return 'plus';
+  return 'value';
+}
+
+/**
+ * Whether the counter's current value sits at the relevant boundary for the
+ * given side zone (ct-d2p). Used by the renderer to dim the zone glyph and
+ * by the pointer pipeline to suppress adjustments.
+ */
+export function isCounterZoneAtBoundary(
+  obj: TableObject,
+  zone: 'minus' | 'plus',
+): boolean {
+  const current = getCounterCurrentValue(obj);
+  if (zone === 'minus') return current <= getCounterMin(obj);
+  return current >= getCounterMax(obj);
+}

--- a/app/src/renderer/objects/counter/utils.ts
+++ b/app/src/renderer/objects/counter/utils.ts
@@ -4,7 +4,6 @@ import {
   COUNTER_DEFAULT_MAX,
   COUNTER_DEFAULT_MIN,
   COUNTER_DEFAULT_STARTING_VALUE,
-  COUNTER_LABEL_HEIGHT_BUMP,
   COUNTER_PILL_HEIGHT,
   COUNTER_PILL_WIDTH,
   COUNTER_TYPE_GENERIC,
@@ -121,30 +120,26 @@ export function getCounterCurrentValue(obj: TableObject): number {
  * Get the pill dimensions (width, height) for a counter in world units.
  *
  * Counters render as a horizontal rounded-rectangle pill (ct-yxh). The
- * width is fixed by `COUNTER_PILL_WIDTH`; the height is normally
- * `COUNTER_PILL_HEIGHT`, but grows by `COUNTER_LABEL_HEIGHT_BUMP` when
- * the counter carries a `text` label (ct-bmk) — just enough extra room
- * for a small label line above the (slightly smaller) numeric value.
- * The pill remains a single rounded-rect silhouette in both states; the
- * entire pill is interactive for +/- hit-testing regardless of whether a
- * label is present.
+ * dimensions are FIXED — `COUNTER_PILL_WIDTH` x `COUNTER_PILL_HEIGHT`
+ * (90x44) — regardless of whether the counter carries a `text` label
+ * (ct-bmk). Bare and labeled counters share one silhouette; only the
+ * text layout inside varies. The entire pill is interactive for +/-
+ * hit-testing in both states.
  */
-export function getCounterDimensions(obj: TableObject): {
+export function getCounterDimensions(_obj: TableObject): {
   width: number;
   height: number;
 } {
-  const hasLabel = hasCounterLabel(obj);
   return {
     width: COUNTER_PILL_WIDTH,
-    height: hasLabel
-      ? COUNTER_PILL_HEIGHT + COUNTER_LABEL_HEIGHT_BUMP
-      : COUNTER_PILL_HEIGHT,
+    height: COUNTER_PILL_HEIGHT,
   };
 }
 
 /**
- * Whether the counter has a non-empty `text` label. Drives the
- * slight height bump on the pill (ct-bmk).
+ * Whether the counter has a non-empty `text` label. Drives the two-line
+ * stacked text layout inside the pill (ct-bmk). The pill dimensions
+ * themselves do NOT change — only the text reflow.
  */
 export function hasCounterLabel(obj: TableObject): boolean {
   const text = getCounterText(obj);

--- a/app/src/renderer/objects/counter/utils.ts
+++ b/app/src/renderer/objects/counter/utils.ts
@@ -4,6 +4,7 @@ import {
   COUNTER_DEFAULT_MAX,
   COUNTER_DEFAULT_MIN,
   COUNTER_DEFAULT_STARTING_VALUE,
+  COUNTER_LABEL_STRIP_HEIGHT,
   COUNTER_PILL_HEIGHT,
   COUNTER_PILL_WIDTH,
   COUNTER_TYPE_GENERIC,
@@ -120,15 +121,48 @@ export function getCounterCurrentValue(obj: TableObject): number {
  * Get the pill dimensions (width, height) for a counter in world units.
  *
  * Counters render as a horizontal rounded-rectangle pill (ct-yxh). The
- * dimensions are fixed by `COUNTER_PILL_WIDTH` / `COUNTER_PILL_HEIGHT`;
- * the parameter is retained for symmetry with the other object kinds and
- * to leave room for per-instance sizing if a future bead introduces it.
+ * width is fixed by `COUNTER_PILL_WIDTH`; the height is normally
+ * `COUNTER_PILL_HEIGHT`, but grows by `COUNTER_LABEL_STRIP_HEIGHT` when
+ * the counter carries a `text` label (ct-ep4). The added strip occupies
+ * the top portion of the pill silhouette; the original height region
+ * (the bottom portion) remains the interactive +/- zone.
  */
-export function getCounterDimensions(_obj: TableObject): {
+export function getCounterDimensions(obj: TableObject): {
   width: number;
   height: number;
 } {
-  return { width: COUNTER_PILL_WIDTH, height: COUNTER_PILL_HEIGHT };
+  const hasLabel = hasCounterLabel(obj);
+  return {
+    width: COUNTER_PILL_WIDTH,
+    height: hasLabel
+      ? COUNTER_PILL_HEIGHT + COUNTER_LABEL_STRIP_HEIGHT
+      : COUNTER_PILL_HEIGHT,
+  };
+}
+
+/**
+ * Whether the counter has a non-empty `text` label. Drives the
+ * label-strip extension of the pill height (ct-ep4).
+ */
+export function hasCounterLabel(obj: TableObject): boolean {
+  const text = getCounterText(obj);
+  return text !== undefined && text.length > 0;
+}
+
+/**
+ * Vertical offset (in local pill coordinates) of the interactive
+ * +/- region's center, relative to the pill's geometric center.
+ *
+ * Pill local-y spans [-height/2, +height/2]. When no label is present
+ * the pill height equals `COUNTER_PILL_HEIGHT` and the interactive
+ * region is the full pill — offset 0. When a label is present, the top
+ * `COUNTER_LABEL_STRIP_HEIGHT` of the pill is reserved for the name and
+ * the interactive region sits below it; its center is shifted down by
+ * half the strip height so the value text/+/- glyphs land centered in
+ * the bottom region rather than the geometric center.
+ */
+export function getCounterInteractiveCenterY(obj: TableObject): number {
+  return hasCounterLabel(obj) ? COUNTER_LABEL_STRIP_HEIGHT / 2 : 0;
 }
 
 /**
@@ -174,12 +208,20 @@ export function counterZoneAtPoint(
     return null;
   }
 
-  const third = width / 3;
-  if (localX < -third / 2 + 0) {
-    // Strictly: left third spans [-halfW, -halfW + third] = [-halfW, -third/2].
-    // The two expressions are equivalent since halfW = 3 * third / 2.
-    // We use the centered split for readability.
+  // When a label strip is present (ct-ep4) only the interactive bottom
+  // region maps to +/- zones; the top strip is the label band. Hits in
+  // the strip itself fall through to `value` (no-op for taps) so taps on
+  // the label area don't accidentally increment/decrement.
+  const interactiveCenterY = getCounterInteractiveCenterY(obj);
+  const interactiveHalfH = COUNTER_PILL_HEIGHT / 2;
+  if (
+    localY < interactiveCenterY - interactiveHalfH ||
+    localY > interactiveCenterY + interactiveHalfH
+  ) {
+    return 'value';
   }
+
+  const third = width / 3;
   if (localX <= -halfW + third) return 'minus';
   if (localX >= halfW - third) return 'plus';
   return 'value';

--- a/app/src/renderer/objects/types.ts
+++ b/app/src/renderer/objects/types.ts
@@ -4,6 +4,20 @@ import type { BBox } from '../SceneManager';
 import type { GameAssets } from '../../content';
 import type { TextureLoader } from '../services/TextureLoader';
 
+/**
+ * Counter-specific visual state passed into the render context (ct-d2p).
+ *
+ * Only meaningful when the rendered object is a Counter. The pointer
+ * pipeline populates `hoveredZone` from local-coordinate hit-testing of
+ * the pill's +/- side zones; `clampFlash` is set by VisualManager for
+ * ~100ms after a tap that hit a min/max boundary, so the body briefly
+ * reads as "not responding" without changing its color.
+ */
+export interface CounterZoneState {
+  readonly hoveredZone: 'minus' | 'plus' | null;
+  readonly clampFlash: boolean;
+}
+
 // Render context provides extra info during rendering
 export interface RenderContext {
   readonly objectId?: string; // ID of the object being rendered - used for triggering visual updates after async operations
@@ -21,6 +35,7 @@ export interface RenderContext {
   readonly gameAssets?: GameAssets | null; // Game assets (cards, tokens, etc.) for texture loading - undefined during initial render before packs load, null when explicitly unset
   readonly textureLoader?: TextureLoader; // Texture loader service for loading card/token images - optional for backward compatibility
   readonly onTextureLoaded?: (url: string) => void; // Callback invoked when a texture finishes loading - used to trigger visual updates
+  readonly counterZoneState?: CounterZoneState; // ct-d2p: per-object Counter zone hover/flash state (Counter renders only)
 }
 
 // Shadow configuration

--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -16,6 +16,7 @@ import {
   detachCard,
   detachAllCards,
   resetTable,
+  adjustCounter,
 } from './YjsActions';
 import {
   ObjectKind,
@@ -3219,5 +3220,108 @@ describe('YjsActions - resetTable', () => {
 
     // gameAssets stay loaded — no reason to invalidate the renderer's caches.
     expect(store.getGameAssets()).toBe(assets);
+  });
+});
+
+describe('YjsActions - adjustCounter (ct-d2p)', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-table-counter-adjust');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    if (store) {
+      store.destroy();
+    }
+  });
+
+  function makeCounter(meta: Record<string, unknown> = {}): string {
+    return createObject(store, {
+      kind: ObjectKind.Counter,
+      pos: { x: 0, y: 0, r: 0 },
+      meta,
+    });
+  }
+
+  function readCounterMeta(id: string): Record<string, unknown> {
+    const obj = toTableObject(store.getObjectYMap(id)!);
+    return obj?._meta ?? {};
+  }
+
+  it('increments currentValue by a positive delta', () => {
+    const id = makeCounter({ startingValue: 3 });
+    const result = adjustCounter(store, id, 1);
+    expect(result).toEqual({ newValue: 4, clamped: false });
+    expect(readCounterMeta(id).currentValue).toBe(4);
+  });
+
+  it('decrements currentValue by a negative delta', () => {
+    const id = makeCounter({ startingValue: 5 });
+    const result = adjustCounter(store, id, -2);
+    expect(result).toEqual({ newValue: 3, clamped: false });
+    expect(readCounterMeta(id).currentValue).toBe(3);
+  });
+
+  it('clamps at max boundary and reports clamped=true with no value change', () => {
+    const id = makeCounter({ startingValue: 99, max: 99 });
+    const result = adjustCounter(store, id, 1);
+    expect(result).toEqual({ newValue: 99, clamped: true });
+    expect(readCounterMeta(id).currentValue).toBe(99);
+  });
+
+  it('clamps at min boundary and reports clamped=true with no value change', () => {
+    const id = makeCounter({ startingValue: 0, min: 0 });
+    const result = adjustCounter(store, id, -1);
+    expect(result).toEqual({ newValue: 0, clamped: true });
+    expect(readCounterMeta(id).currentValue).toBe(0);
+  });
+
+  it('clamps a multi-step delta to the boundary (still reports the new clamped value)', () => {
+    const id = makeCounter({ startingValue: 5, max: 7 });
+    const result = adjustCounter(store, id, 10);
+    // We started at 5, requested +10, clamped to 7. The "clamped" flag in
+    // the result type is reserved for "no movement at all" boundary taps;
+    // a delta that moved the value but was capped is still reported as
+    // clamped=false because the consumer doesn't need to flash.
+    expect(result).toEqual({ newValue: 7, clamped: false });
+    expect(readCounterMeta(id).currentValue).toBe(7);
+  });
+
+  it('returns null for non-Counter kinds', () => {
+    const id = createObject(store, {
+      kind: ObjectKind.Token,
+      pos: { x: 0, y: 0, r: 0 },
+    });
+    const result = adjustCounter(store, id, 1);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for missing object', () => {
+    const result = adjustCounter(store, 'no-such-id', 1);
+    expect(result).toBeNull();
+  });
+
+  it('preserves all other meta fields when writing the new currentValue', () => {
+    const id = makeCounter({
+      color: 0xabcdef,
+      text: 'HP',
+      min: -5,
+      max: 10,
+      startingValue: 3,
+    });
+    adjustCounter(store, id, 2);
+    const meta = readCounterMeta(id);
+    expect(meta).toMatchObject({
+      type: 'generic',
+      typeId: 'generic',
+      color: 0xabcdef,
+      text: 'HP',
+      min: -5,
+      max: 10,
+      startingValue: 3,
+      currentValue: 5,
+    });
   });
 });

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1149,6 +1149,80 @@ export function detachAllCards(store: YjsStore, parentId: string): string[] {
 }
 
 /**
+ * Result of an `adjustCounter` call.
+ */
+export interface AdjustCounterResult {
+  /** Counter's new `currentValue` after clamping to `[min, max]`. */
+  newValue: number;
+  /**
+   * `true` when the requested delta would have pushed `currentValue` past a
+   * boundary and was therefore clamped — that is, the value did not change
+   * at all (already at min/max in the direction requested). Callers use this
+   * to drive boundary feedback (e.g. clamp-flash) without separately reading
+   * the counter's prior value.
+   */
+  clamped: boolean;
+}
+
+/**
+ * Increment/decrement a counter's `currentValue` (ct-d2p).
+ *
+ * Reads `_meta.{currentValue,min,max}` directly from the counter's Y.Map,
+ * applies `delta`, clamps to `[min, max]`, and writes back a new `_meta`
+ * Y.Map entry. The full meta record is replaced atomically inside a Yjs
+ * transaction so multiplayer peers see a single coherent update.
+ *
+ * No-op (returns `clamped: true`) when the counter is already at the
+ * boundary in the direction requested. Also a no-op for any non-Counter
+ * object, missing counter, or `delta === 0`.
+ *
+ * @param store - YjsStore instance
+ * @param id - Counter object ID
+ * @param delta - Signed change to apply (typically +1/-1)
+ * @returns Result with the post-adjust value and a clamp flag, or `null`
+ *          when the object is missing or not a Counter.
+ */
+export function adjustCounter(
+  store: YjsStore,
+  id: string,
+  delta: number,
+): AdjustCounterResult | null {
+  const yMap = store.getObjectYMap(id);
+  if (!yMap) {
+    console.warn(`[adjustCounter] Object ${id} not found`);
+    return null;
+  }
+
+  if (yMap.get('_kind') !== ObjectKind.Counter) {
+    console.warn(`[adjustCounter] Object ${id} is not a Counter`);
+    return null;
+  }
+
+  // Defensive: a counter materialised through `createObject` always has a
+  // fully-populated `_meta`, but reading directly from Y.Map means another
+  // peer could in principle write a partial record. Fall back to the same
+  // constants `createCounterMeta` would use so we never write NaN.
+  const currentMeta = (yMap.get('_meta') as Partial<CounterMeta>) ?? {};
+  const min = currentMeta.min ?? 0;
+  const max = currentMeta.max ?? 99;
+  const startingValue = currentMeta.startingValue ?? 0;
+  const oldValue = currentMeta.currentValue ?? startingValue;
+
+  const desired = oldValue + delta;
+  const clamped = Math.max(min, Math.min(max, desired));
+
+  if (clamped === oldValue) {
+    return { newValue: oldValue, clamped: true };
+  }
+
+  store.getDoc().transact(() => {
+    yMap.set('_meta', { ...currentMeta, currentValue: clamped });
+  });
+
+  return { newValue: clamped, clamped: false };
+}
+
+/**
  * Reset the table to a test scene with various object types.
  * Useful for development and testing.
  *

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -354,6 +354,11 @@ export type RendererToMainMessage =
   | {
       type: 'detach-card'; // Card-on-card attachment: detach a card from its parent
       cardId: string; // Stack ID of the attached card to detach
+    }
+  | {
+      type: 'counter-adjust'; // Counter +/- zone tapped: increment/decrement currentValue
+      id: string; // Counter object ID
+      delta: number; // Signed change to apply (+1 or -1 from a zone tap)
     };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Wires up the Counter pill's +/- interaction (events, hover/active feedback, min/max clamping, keyboard shortcut) and iterates the visual treatment so labeled and bare counters share one pill silhouette. Final commit fixes a rapid-tap loss bug.

### Interaction (ct-d2p)
- New `counter-adjust` renderer→main message + `adjustCounter` store action with min/max-aware clamping.
- Hover state plumbed through `HoverManager` → `RenderContext.counterZoneState` → `behaviors.ts`. Hovering a +/- zone brightens its glyph and adds a subtle tint to that third of the pill; at rest, glyphs sit at ~0.55 alpha.
- Click hit-testing in `pointer.ts` routes to `counter-adjust`. At min/max boundary the relevant zone alpha drops to ~0.25 and stops responding; a 100ms white-tint clamp flash overlays the pill body. Body color is preserved (no recolor).
- Keyboard `=` / `-` increment/decrement when a single Counter is selected (gated on `SelectionInfo.hasCounters` + `selection.count === 1`).

### Visual iteration: labeled-counter layout (ct-ep4 → ct-bmk)
- **ct-ep4**: First pass grew the pill with a dedicated top label strip and added a `roundRect` mask so the hover-tint / clamp-flash Graphics stay clipped to the rounded silhouette.
- **ct-bmk (stacked layout)**: Replaced the strip approach (read as two awkward rectangles) with a simple two-line stacked text layout — small label above value — inside one consistent silhouette. Removed `COUNTER_LABEL_STRIP_HEIGHT`, `getCounterInteractiveCenterY`, and the label-strip special-case in `counterZoneAtPoint`. Entire pill is now interactive for +/- in both states.
- **ct-bmk (lock dimensions)**: Pill height is now fixed at 44px in both states; only the text layout reflows. Bare and labeled counters share identical silhouettes (verified at 0.5x zoom: both render 70 canvas-pixels tall).

### Bug fix: rapid-tap loss (ct-m3h)
- Pre-fix, ~50% of rapid `+`/`-` taps were silently dropped because hand jitter crossed the 3px drag-slop threshold during the down→up window, classifying the interaction as a drag and gating out the counter-adjust on pointer-up.
- Fix: skip drag prep entirely for `+`/`-` zones in `handlePointerDown` so pointer-up always classifies as a click. The center "value" zone keeps normal drag prep so the counter is still draggable by its body.

## Note on the keyboard binding
`=` is bound, not `+`. `KeyboardManager.normalizeShortcut` uses `+` as the modifier separator (`Ctrl+Shift+X`), so a literal `+` key can't be represented. `=` is the same physical key on US layouts so this is a reasonable substitute. Followup: **ct-o7z** tracks whether to grow escaping support in KeyboardManager.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (1323 passing as of the last layout refactor)
- [x] Manual MCP at `/table/<id>` with testgame plugin:
  - Tap `+`/`-` zones — value increments / decrements
  - Rapid-tap +/- 10 times — value increments exactly 10 (ct-m3h regression check)
  - At max (99), `+` glyph visibly dimmer; tap leaves value unchanged
  - At min (0), `-` glyph dimmer; tap leaves value unchanged
  - Hover brightens glyph + adds subtle zone tint, clipped to pill silhouette
  - Bare and labeled counters render with identical pill bounds
  - Keyboard `=` / `-` when single counter selected; no fire after deselect
  - Counter remains draggable by its center "value" zone

## Followups
- **ct-o7z**: KeyboardManager `+`-vs-modifier-separator question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)