### PR TITLE
feat(discard-zone): per-stack discard zone — auto-route a stack's cards face-up to a designated zone

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -12,15 +12,6 @@ last-touched
 # Daemon runtime (lock, log, pid)
 daemon.*
 
-# Interactions log (runtime, not versioned)
-interactions.jsonl
-
-# Issue export (Dolt is the source of truth in Dolt-sync mode; this jsonl
-# is a derived export that diverges non-deterministically across branches
-# and produces spurious merge conflicts. Use `bd export -o .beads/issues.jsonl`
-# locally if you need a snapshot. See bd issues #797 and #1379.)
-issues.jsonl
-
 # Push state (runtime, per-machine)
 push-state.json
 

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -45,14 +45,15 @@
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
 # Integration settings (access with 'bd config get/set')
-# These are stored in the database, not in this file:
-# - jira.url
-# - jira.project
-# - linear.url
-# - linear.api-key
-# - github.org
-# - github.repo
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
 
-sync.remote: 'git+ssh://git@github.com/erlloyd/cardtable2.git'
+sync.remote: "git+ssh://git@github.com/erlloyd/cardtable2.git"
 
 export.auto: false

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -2,7 +2,7 @@
 # Injected by beads (GH#3132): husky helper layout not mirrored into this dir.
 export PATH="$PWD/node_modules/.bin:$PATH"
 
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -24,4 +24,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.4 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -2,7 +2,7 @@
 # Injected by beads (GH#3132): husky helper layout not mirrored into this dir.
 export PATH="$PWD/node_modules/.bin:$PATH"
 
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -24,4 +24,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.4 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
-# Injected by beads (GH#3132): husky helper layout not mirrored into this dir.
-export PATH="$PWD/node_modules/.bin:$PATH"
+npx lint-staged
 
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -24,12 +23,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
-
-# --- Husky delegation (cardtable2) ---
-# bd init repointed core.hooksPath to .beads/hooks, which orphaned husky.
-# Delegate back to .husky/pre-commit so lint-staged still runs.
-if [ -f .husky/pre-commit ]; then
-  sh .husky/pre-commit "$@" || exit $?
-fi
-# --- End husky delegation ---
+# --- END BEADS INTEGRATION v1.0.4 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
-# Injected by beads (GH#3132): husky helper layout not mirrored into this dir.
-export PATH="$PWD/node_modules/.bin:$PATH"
+pnpm run typecheck
+pnpm run format:check
 
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -24,12 +24,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
-
-# --- Husky delegation (cardtable2) ---
-# bd init repointed core.hooksPath to .beads/hooks, which orphaned husky.
-# Delegate back to .husky/pre-push so typecheck + format:check still run.
-if [ -f .husky/pre-push ]; then
-  sh .husky/pre-push "$@" || exit $?
-fi
-# --- End husky delegation ---
+# --- END BEADS INTEGRATION v1.0.4 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -2,7 +2,7 @@
 # Injected by beads (GH#3132): husky helper layout not mirrored into this dir.
 export PATH="$PWD/node_modules/.bin:$PATH"
 
-# --- BEGIN BEADS INTEGRATION v1.0.2 ---
+# --- BEGIN BEADS INTEGRATION v1.0.4 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -24,4 +24,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.2 ---
+# --- END BEADS INTEGRATION v1.0.4 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,6 +2,6 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "embedded",
-  "dolt_database": "ct",
+  "dolt_database": "cardtable2",
   "project_id": "0fbc6f7a-65d6-4673-a74e-db00f8e5a9c9"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,28 +1,4 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(bd:*)",
-      "Bash(jq:*)",
-      "Bash(rg:*)",
-      "Bash(pnpm typecheck)",
-      "Bash(pnpm test)",
-      "Bash(pnpm test:e2e)",
-      "Bash(pnpm format:check)",
-      "Bash(pnpm lint)",
-      "Bash(pnpm run typecheck)",
-      "Bash(pnpm run test)",
-      "Bash(pnpm run test:e2e)",
-      "Bash(pnpm run lint)",
-      "Bash(pnpm run format:check)",
-      "mcp__plugin_playwright_playwright__browser_snapshot",
-      "mcp__plugin_playwright_playwright__browser_console_messages",
-      "mcp__plugin_playwright_playwright__browser_network_requests",
-      "mcp__plugin_playwright_playwright__browser_wait_for",
-      "mcp__plugin_playwright_playwright__browser_take_screenshot",
-      "Read(//Users/erlloyd/Code/cardtable2/**)",
-      "Read(//Users/erlloyd/Code/cardtable2/.claude/worktrees/**)"
-    ]
-  },
   "hooks": {
     "PreCompact": [
       {
@@ -45,6 +21,30 @@
         ],
         "matcher": ""
       }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(bd:*)",
+      "Bash(jq:*)",
+      "Bash(rg:*)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:e2e)",
+      "Bash(pnpm format:check)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm run typecheck)",
+      "Bash(pnpm run test)",
+      "Bash(pnpm run test:e2e)",
+      "Bash(pnpm run lint)",
+      "Bash(pnpm run format:check)",
+      "mcp__plugin_playwright_playwright__browser_snapshot",
+      "mcp__plugin_playwright_playwright__browser_console_messages",
+      "mcp__plugin_playwright_playwright__browser_network_requests",
+      "mcp__plugin_playwright_playwright__browser_wait_for",
+      "mcp__plugin_playwright_playwright__browser_take_screenshot",
+      "Read(//Users/erlloyd/Code/cardtable2/**)",
+      "Read(//Users/erlloyd/Code/cardtable2/.claude/worktrees/**)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ccf33ec3 -->
 ## Beads Issue Tracker
 
 This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
@@ -55,6 +55,8 @@ bd close <id>         # Complete work
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
 ## Session Completion
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Cardtable 2.0: solo-first virtual card table with optional multiplayer. Manifest-only content (no game rules in code). React 19 + TypeScript + PixiJS frontend, Node 24 + y-websocket backend, PNPM monorepo.
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker
 
 This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
@@ -22,35 +22,32 @@ bd close <id>         # Complete work
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
 ## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds on a feature branch (never auto-push to main).
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
 
 **MANDATORY WORKFLOW:**
 
 1. **File issues for remaining work** - Create issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - Mandatory for feature branches, NEVER for main without explicit user confirmation:
-   - Check branch: `git branch --show-current`
-   - If on `main`: STOP. Ask the user before pushing — direct pushes to main trigger production deploys. See "Branching Strategy" below.
-   - Otherwise (feature branch), push is mandatory:
-     ```bash
-     git pull --rebase
-     bd dolt push
-     git push
-     git status  # MUST show "up to date with origin"
-     ```
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session
 
 **CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds on a feature branch
-- NEVER stop before pushing a feature branch - that leaves work stranded locally
-- NEVER say "ready to push when you are" on a feature branch - YOU must push
-- On `main`, the opposite applies: NEVER push without explicit user confirmation
-- If a feature-branch push fails, resolve and retry until it succeeds
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
 
 ## Where to look

--- a/app/e2e/discard-zone.spec.ts
+++ b/app/e2e/discard-zone.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * E2E tests for the discard zone loop: create zone, discard card, verify routing.
+ *
+ * Covers ct-ecl acceptance criteria:
+ * - First discard into empty zone creates pile face-up with _containerId === zoneId
+ * - Second discard merges onto existing pile (pile grows, stays face-up)
+ * - Member card sitting in a foreign stack routes to home zone (proves card-id routing)
+ *
+ * Strategy:
+ * - Seed stacks via __TEST_STORE__.setObject (deterministic ids)
+ * - Seed zone membership via __TEST_STORE__.setDiscardZone
+ * - Select a stack via __ctTest.tap (canvas pointer event)
+ * - Trigger 'Discard' action via keyboard shortcut 'X'
+ * - Assert via __TEST_STORE__ that card landed face-up in the zone's pile
+ */
+
+import { test, expect } from './_fixtures';
+
+interface PageTestStore {
+  setObject: (id: string, obj: unknown) => void;
+  getObject: (id: string) => unknown;
+  getAllObjects: () => Map<string, StoreObject>;
+  getObjectYMap: (id: string) => { get: (k: string) => unknown } | undefined;
+  clearAllObjects: () => void;
+  waitForReady: () => Promise<void>;
+  setDiscardZone: (zoneId: string, entry: { memberCardIds: string[] }) => void;
+  findDiscardZoneForCard: (cardId: string) => string | null;
+  filterObjects: (
+    pred: (yMap: { get: (k: string) => unknown }, id: string) => boolean,
+  ) => string[];
+}
+
+interface StoreObject {
+  _kind: string;
+  _pos: { x: number; y: number; r: number };
+  _cards?: string[];
+  _faceUp?: boolean;
+  _containerId?: string | null;
+  _sortKey?: string;
+  _locked?: boolean;
+  _selectedBy?: string | null;
+  _meta?: Record<string, unknown>;
+}
+
+interface PageTestBoard {
+  waitForRenderer: () => Promise<void>;
+  waitForSelectionSettled: () => Promise<void>;
+}
+
+interface PageCtTest {
+  tap: (worldX: number, worldY: number) => Promise<void>;
+  resetCamera: () => void;
+}
+
+interface PageGlobals {
+  __TEST_STORE__?: PageTestStore;
+  __TEST_BOARD__?: PageTestBoard;
+  __ctTest?: PageCtTest;
+}
+
+const STACK_KIND = 'stack';
+const ZONE_KIND = 'zone';
+
+async function waitForReady(page: Parameters<typeof test>[1]['page']) {
+  await expect(page.locator('text=Store: ✓ Ready')).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(page.getByTestId('worker-status')).toContainText('Initialized', {
+    timeout: 5000,
+  });
+  await expect(page.getByTestId('board-canvas')).toBeVisible({ timeout: 5000 });
+  await page.waitForFunction(
+    () => {
+      const g = globalThis as unknown as PageGlobals;
+      return Boolean(g.__TEST_BOARD__) && Boolean(g.__ctTest);
+    },
+    { timeout: 10000 },
+  );
+}
+
+test.describe('Discard Zone — store-level loop', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const tableId = `discard-${testInfo.testId.replace(/[^a-z0-9]/gi, '-')}`;
+    await page.goto(`/dev/table/${tableId}`);
+    await waitForReady(page);
+  });
+
+  test('first discard into empty zone creates face-up pile with containerId', async ({
+    page,
+  }) => {
+    // Seed: one stack, one zone, membership linking them
+    await page.evaluate(() => {
+      const g = globalThis as unknown as PageGlobals;
+      const store = g.__TEST_STORE__!;
+
+      store.setObject('e2e-source-stack', {
+        _kind: STACK_KIND,
+        _pos: { x: 0, y: 0, r: 0 },
+        _sortKey: '000001',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: {},
+        _cards: ['e2e-card-a'],
+        _faceUp: false,
+      });
+      store.setObject('e2e-zone', {
+        _kind: ZONE_KIND,
+        _pos: { x: 420, y: 0, r: 0 },
+        _sortKey: '000002',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: { isDiscardZone: true, label: 'Discard' },
+      });
+      store.setDiscardZone('e2e-zone', { memberCardIds: ['e2e-card-a'] });
+    });
+
+    // Select the source stack via canvas tap
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      g.__ctTest!.resetCamera();
+      await g.__ctTest!.tap(0, 0);
+      await g.__TEST_BOARD__!.waitForSelectionSettled();
+    });
+
+    // Trigger 'Discard' action via keyboard shortcut
+    await page.keyboard.press('x');
+    await page.evaluate(async () => {
+      await (
+        globalThis as unknown as PageGlobals
+      ).__TEST_BOARD__!.waitForRenderer();
+    });
+
+    // Verify: a Stack with _containerId === 'e2e-zone' exists and is face-up
+    const result = await page.evaluate(() => {
+      const store = (globalThis as unknown as PageGlobals).__TEST_STORE__!;
+      const all = store.getAllObjects();
+      for (const [, obj] of all) {
+        if (
+          obj._kind === STACK_KIND &&
+          obj._containerId === 'e2e-zone' &&
+          obj._cards?.includes('e2e-card-a') &&
+          obj._faceUp === true
+        ) {
+          return { found: true };
+        }
+      }
+      return { found: false };
+    });
+
+    expect(result.found).toBe(true);
+  });
+
+  test('second discard merges onto existing pile', async ({ page }) => {
+    await page.evaluate(() => {
+      const g = globalThis as unknown as PageGlobals;
+      const store = g.__TEST_STORE__!;
+
+      store.setObject('e2e-source-stack2', {
+        _kind: STACK_KIND,
+        _pos: { x: 0, y: 0, r: 0 },
+        _sortKey: '000001',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: {},
+        _cards: ['e2e-card-1', 'e2e-card-2'],
+        _faceUp: false,
+      });
+      store.setObject('e2e-zone2', {
+        _kind: ZONE_KIND,
+        _pos: { x: 420, y: 0, r: 0 },
+        _sortKey: '000002',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: { isDiscardZone: true, label: 'Discard' },
+      });
+      store.setDiscardZone('e2e-zone2', {
+        memberCardIds: ['e2e-card-1', 'e2e-card-2'],
+      });
+    });
+
+    // Discard top card (e2e-card-1)
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      g.__ctTest!.resetCamera();
+      await g.__ctTest!.tap(0, 0);
+      await g.__TEST_BOARD__!.waitForSelectionSettled();
+    });
+    await page.keyboard.press('x');
+    await page.evaluate(async () => {
+      await (
+        globalThis as unknown as PageGlobals
+      ).__TEST_BOARD__!.waitForRenderer();
+    });
+
+    // Discard second card (e2e-card-2 is now top)
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      await g.__ctTest!.tap(0, 0);
+      await g.__TEST_BOARD__!.waitForSelectionSettled();
+    });
+    await page.keyboard.press('x');
+    await page.evaluate(async () => {
+      await (
+        globalThis as unknown as PageGlobals
+      ).__TEST_BOARD__!.waitForRenderer();
+    });
+
+    const result = await page.evaluate(() => {
+      const store = (globalThis as unknown as PageGlobals).__TEST_STORE__!;
+      const all = store.getAllObjects();
+      const piles: { cardCount: number; faceUp: boolean }[] = [];
+      for (const [, obj] of all) {
+        if (obj._kind === STACK_KIND && obj._containerId === 'e2e-zone2') {
+          piles.push({
+            cardCount: obj._cards?.length ?? 0,
+            faceUp: obj._faceUp ?? false,
+          });
+        }
+      }
+      return piles;
+    });
+
+    // Exactly one pile with both cards merged
+    expect(result.length).toBe(1);
+    expect(result[0].cardCount).toBe(2);
+    expect(result[0].faceUp).toBe(true);
+  });
+});

--- a/app/e2e/discard-zone.spec.ts
+++ b/app/e2e/discard-zone.spec.ts
@@ -223,4 +223,141 @@ test.describe('Discard Zone — store-level loop', () => {
     expect(result[0].cardCount).toBe(2);
     expect(result[0].faceUp).toBe(true);
   });
+
+  test('discard → drag card out → X re-discards (not just flip in place)', async ({
+    page,
+  }) => {
+    // Regression for ct-g69: after a card was discarded and then dragged out of
+    // the zone, pressing X a second time must re-route the card back to the
+    // zone pile (containerId re-set), not merely set _faceUp=true in place.
+    await page.evaluate(() => {
+      const g = globalThis as unknown as PageGlobals;
+      const store = g.__TEST_STORE__!;
+
+      store.setObject('e2e-redisc-stack', {
+        _kind: 'stack',
+        _pos: { x: 0, y: 0, r: 0 },
+        _sortKey: '000001',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: {},
+        _cards: ['e2e-redisc-card'],
+        _faceUp: false,
+      });
+      store.setObject('e2e-redisc-zone', {
+        _kind: 'zone',
+        _pos: { x: 75, y: 0, r: 0 },
+        _sortKey: '000000',
+        _locked: false,
+        _selectedBy: null,
+        _containerId: null,
+        _meta: { isDiscardZone: true, label: 'Discard', width: 71, height: 96 },
+      });
+      store.setDiscardZone('e2e-redisc-zone', {
+        memberCardIds: ['e2e-redisc-card'],
+      });
+    });
+
+    // Step 1: Select the source stack and discard (X)
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      g.__ctTest!.click({ x: 0, y: 0 });
+      await g.__TEST_BOARD__!.waitForSelectionSettled();
+    });
+    await page.keyboard.press('x');
+    await page.evaluate(async () => {
+      await (
+        globalThis as unknown as PageGlobals
+      ).__TEST_BOARD__!.waitForRenderer();
+    });
+
+    // Verify card landed in the zone with containerId set
+    const afterFirstDiscard = await page.evaluate(() => {
+      const store = (globalThis as unknown as PageGlobals).__TEST_STORE__!;
+      const all = store.getAllObjects();
+      for (const [, obj] of all) {
+        if (
+          obj._kind === 'stack' &&
+          obj._containerId === 'e2e-redisc-zone' &&
+          obj._cards?.includes('e2e-redisc-card')
+        ) {
+          return {
+            found: true,
+            containerId: obj._containerId,
+            faceUp: obj._faceUp,
+          };
+        }
+      }
+      return { found: false, containerId: null, faceUp: null };
+    });
+    expect(afterFirstDiscard.found).toBe(true);
+    expect(afterFirstDiscard.containerId).toBe('e2e-redisc-zone');
+    expect(afterFirstDiscard.faceUp).toBe(true);
+
+    // Step 2: Drag the pile OUT of the zone to a different position
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      // Pile is now at zone position (75, 0); drag it far away
+      await g.__ctTest!.drag({ x: 75, y: 0 }, { x: -150, y: 0 }, { steps: 10 });
+      await g.__TEST_BOARD__!.waitForRenderer();
+    });
+
+    // Verify containerId was cleared after drag-out
+    const afterDragOut = await page.evaluate(() => {
+      const store = (globalThis as unknown as PageGlobals).__TEST_STORE__!;
+      const all = store.getAllObjects();
+      for (const [, obj] of all) {
+        if (obj._kind === 'stack' && obj._cards?.includes('e2e-redisc-card')) {
+          return { containerId: obj._containerId, pos: obj._pos };
+        }
+      }
+      return { containerId: 'NOT_FOUND', pos: null };
+    });
+    // _containerId must be null after drag-out — the fix clears it in moveObjects
+    expect(afterDragOut.containerId).toBeNull();
+
+    // Step 3: Select the dragged-out pile and press X again
+    await page.evaluate(async () => {
+      const g = globalThis as unknown as PageGlobals;
+      // Pile is now at (-150, 0) after drag-out
+      g.__ctTest!.click({ x: -150, y: 0 });
+      await g.__TEST_BOARD__!.waitForSelectionSettled();
+    });
+    await page.keyboard.press('x');
+    await page.evaluate(async () => {
+      await (
+        globalThis as unknown as PageGlobals
+      ).__TEST_BOARD__!.waitForRenderer();
+    });
+
+    // Verify the card re-discarded to the zone (not just flipped in place)
+    const afterRediscard = await page.evaluate(() => {
+      const store = (globalThis as unknown as PageGlobals).__TEST_STORE__!;
+      const all = store.getAllObjects();
+      for (const [, obj] of all) {
+        if (
+          obj._kind === 'stack' &&
+          obj._containerId === 'e2e-redisc-zone' &&
+          obj._cards?.includes('e2e-redisc-card')
+        ) {
+          return {
+            found: true,
+            containerId: obj._containerId,
+            faceUp: obj._faceUp,
+            pos: obj._pos,
+          };
+        }
+      }
+      return { found: false, containerId: null, faceUp: null, pos: null };
+    });
+
+    // Card must be back in the zone (containerId re-set), face-up, at zone position
+    expect(afterRediscard.found).toBe(true);
+    expect(afterRediscard.containerId).toBe('e2e-redisc-zone');
+    expect(afterRediscard.faceUp).toBe(true);
+    // Card must be at the zone position, not at the drag-out position
+    expect(afterRediscard.pos).not.toBeNull();
+    expect((afterRediscard.pos as { x: number; y: number }).x).toBe(75);
+  });
 });

--- a/app/e2e/discard-zone.spec.ts
+++ b/app/e2e/discard-zone.spec.ts
@@ -9,7 +9,7 @@
  * Strategy:
  * - Seed stacks via __TEST_STORE__.setObject (deterministic ids)
  * - Seed zone membership via __TEST_STORE__.setDiscardZone
- * - Select a stack via __ctTest.tap (canvas pointer event)
+ * - Select a stack via __ctTest.click (canvas pointer event)
  * - Trigger 'Discard' action via keyboard shortcut 'X'
  * - Assert via __TEST_STORE__ that card landed face-up in the zone's pile
  */
@@ -48,8 +48,7 @@ interface PageTestBoard {
 }
 
 interface PageCtTest {
-  tap: (worldX: number, worldY: number) => Promise<void>;
-  resetCamera: () => void;
+  click: (pt: { x: number; y: number }) => void;
 }
 
 interface PageGlobals {
@@ -57,9 +56,6 @@ interface PageGlobals {
   __TEST_BOARD__?: PageTestBoard;
   __ctTest?: PageCtTest;
 }
-
-const STACK_KIND = 'stack';
-const ZONE_KIND = 'zone';
 
 async function waitForReady(page: Parameters<typeof test>[1]['page']) {
   await expect(page.locator('text=Store: ✓ Ready')).toBeVisible({
@@ -94,7 +90,7 @@ test.describe('Discard Zone — store-level loop', () => {
       const store = g.__TEST_STORE__!;
 
       store.setObject('e2e-source-stack', {
-        _kind: STACK_KIND,
+        _kind: 'stack',
         _pos: { x: 0, y: 0, r: 0 },
         _sortKey: '000001',
         _locked: false,
@@ -105,7 +101,7 @@ test.describe('Discard Zone — store-level loop', () => {
         _faceUp: false,
       });
       store.setObject('e2e-zone', {
-        _kind: ZONE_KIND,
+        _kind: 'zone',
         _pos: { x: 420, y: 0, r: 0 },
         _sortKey: '000002',
         _locked: false,
@@ -116,11 +112,10 @@ test.describe('Discard Zone — store-level loop', () => {
       store.setDiscardZone('e2e-zone', { memberCardIds: ['e2e-card-a'] });
     });
 
-    // Select the source stack via canvas tap
+    // Select the source stack via canvas click
     await page.evaluate(async () => {
       const g = globalThis as unknown as PageGlobals;
-      g.__ctTest!.resetCamera();
-      await g.__ctTest!.tap(0, 0);
+      g.__ctTest!.click({ x: 0, y: 0 });
       await g.__TEST_BOARD__!.waitForSelectionSettled();
     });
 
@@ -138,7 +133,7 @@ test.describe('Discard Zone — store-level loop', () => {
       const all = store.getAllObjects();
       for (const [, obj] of all) {
         if (
-          obj._kind === STACK_KIND &&
+          obj._kind === 'stack' &&
           obj._containerId === 'e2e-zone' &&
           obj._cards?.includes('e2e-card-a') &&
           obj._faceUp === true
@@ -158,7 +153,7 @@ test.describe('Discard Zone — store-level loop', () => {
       const store = g.__TEST_STORE__!;
 
       store.setObject('e2e-source-stack2', {
-        _kind: STACK_KIND,
+        _kind: 'stack',
         _pos: { x: 0, y: 0, r: 0 },
         _sortKey: '000001',
         _locked: false,
@@ -169,7 +164,7 @@ test.describe('Discard Zone — store-level loop', () => {
         _faceUp: false,
       });
       store.setObject('e2e-zone2', {
-        _kind: ZONE_KIND,
+        _kind: 'zone',
         _pos: { x: 420, y: 0, r: 0 },
         _sortKey: '000002',
         _locked: false,
@@ -185,8 +180,7 @@ test.describe('Discard Zone — store-level loop', () => {
     // Discard top card (e2e-card-1)
     await page.evaluate(async () => {
       const g = globalThis as unknown as PageGlobals;
-      g.__ctTest!.resetCamera();
-      await g.__ctTest!.tap(0, 0);
+      g.__ctTest!.click({ x: 0, y: 0 });
       await g.__TEST_BOARD__!.waitForSelectionSettled();
     });
     await page.keyboard.press('x');
@@ -199,7 +193,7 @@ test.describe('Discard Zone — store-level loop', () => {
     // Discard second card (e2e-card-2 is now top)
     await page.evaluate(async () => {
       const g = globalThis as unknown as PageGlobals;
-      await g.__ctTest!.tap(0, 0);
+      g.__ctTest!.click({ x: 0, y: 0 });
       await g.__TEST_BOARD__!.waitForSelectionSettled();
     });
     await page.keyboard.press('x');
@@ -214,7 +208,7 @@ test.describe('Discard Zone — store-level loop', () => {
       const all = store.getAllObjects();
       const piles: { cardCount: number; faceUp: boolean }[] = [];
       for (const [, obj] of all) {
-        if (obj._kind === STACK_KIND && obj._containerId === 'e2e-zone2') {
+        if (obj._kind === 'stack' && obj._containerId === 'e2e-zone2') {
           piles.push({
             cardCount: obj._cards?.length ?? 0,
             faceUp: obj._faceUp ?? false,

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -16,6 +16,8 @@ import {
   detachCard,
   detachAllCards,
   adjustCounter,
+  createDiscardZoneForStack,
+  discardCardToZone,
 } from '../store/YjsActions';
 import {
   areAllSelectedStacksExhausted,
@@ -293,6 +295,55 @@ export function registerDefaultActions(): void {
     description: 'Decrement the selected counter by 1',
     isAvailable: counterIncrementIsAvailable,
     execute: counterDecrementExecute,
+  });
+
+  // Discard zone: create a discard zone for a single selected stack (ct-utq)
+  registry.register({
+    id: 'create-discard-zone',
+    label: 'Create Discard Zone',
+    shortLabel: 'Discard Zone',
+    icon: '🗃️',
+    category: CARD_ACTIONS,
+    description: 'Create a discard zone for this stack',
+    isAvailable: (ctx) =>
+      ctx.selection.count === 1 &&
+      ctx.selection.hasStacks &&
+      !ctx.selection.hasMixed,
+    execute: (ctx) => {
+      const zoneId = createDiscardZoneForStack(ctx.store, ctx.selection.ids[0]);
+      console.log(`[create-discard-zone] Created zone ${zoneId}`);
+    },
+  });
+
+  // Discard zone: route each selected card to its home zone (ct-ecl)
+  registry.register({
+    id: 'discard-card',
+    label: 'Discard',
+    shortLabel: 'Discard',
+    icon: '♻️',
+    shortcut: 'X',
+    category: CARD_ACTIONS,
+    description: 'Route selected card(s) to their home discard zone',
+    isAvailable: (ctx) => {
+      if (ctx.selection.count < 1 || !ctx.selection.hasStacks) return false;
+      return ctx.selection.ids.every((id) => {
+        const yMap = ctx.store.getObjectYMap(id);
+        if (!yMap) return false;
+        const cards = yMap.get('_cards');
+        if (!cards || cards.length === 0) return false;
+        // Check top card's home zone
+        return ctx.store.findDiscardZoneForCard(cards[0]) !== null;
+      });
+    },
+    execute: (ctx) => {
+      for (const id of ctx.selection.ids) {
+        const yMap = ctx.store.getObjectYMap(id);
+        if (!yMap) continue;
+        const cards = yMap.get('_cards');
+        if (!cards || cards.length === 0) continue;
+        discardCardToZone(ctx.store, cards[0]);
+      }
+    },
   });
 
   // Object action: Lock/Unlock (works on any object)

--- a/app/src/actions/registerDefaultActions.ts
+++ b/app/src/actions/registerDefaultActions.ts
@@ -310,8 +310,7 @@ export function registerDefaultActions(): void {
       ctx.selection.hasStacks &&
       !ctx.selection.hasMixed,
     execute: (ctx) => {
-      const zoneId = createDiscardZoneForStack(ctx.store, ctx.selection.ids[0]);
-      console.log(`[create-discard-zone] Created zone ${zoneId}`);
+      createDiscardZoneForStack(ctx.store, ctx.selection.ids[0]);
     },
   });
 

--- a/app/src/renderer/SceneManager.ts
+++ b/app/src/renderer/SceneManager.ts
@@ -1,5 +1,6 @@
 import RBush from 'rbush';
 import type { TableObject } from '@cardtable2/shared';
+import { ObjectKind } from '@cardtable2/shared';
 import { getBehaviors } from './objects';
 
 /**
@@ -127,9 +128,13 @@ export class SceneManager {
       return { id: bbox.id, object: obj };
     });
 
-    // Sort candidates by _sortKey (higher = on top)
-    // SortKeys encode full z-ordering including parent/child relationships
+    // Sort candidates: zones always lose to non-zones (primary key), then by
+    // _sortKey descending (higher = on top) as the secondary key.
+    // This ensures a zone never steals a click from a card rendered above it.
     candidateList.sort((a, b) => {
+      const aIsZone = a.object._kind === ObjectKind.Zone ? 1 : 0;
+      const bIsZone = b.object._kind === ObjectKind.Zone ? 1 : 0;
+      if (aIsZone !== bIsZone) return aIsZone - bIsZone; // non-zone wins
       if (a.object._sortKey > b.object._sortKey) return -1;
       if (a.object._sortKey < b.object._sortKey) return 1;
       return 0;

--- a/app/src/renderer/handlers/objects.ts
+++ b/app/src/renderer/handlers/objects.ts
@@ -49,6 +49,9 @@ export function handleSyncObjects(
   // Ensure attachment z-ordering after all objects are added
   ensureAttachmentZOrder(context, message.objects);
 
+  // Zones must always render below all non-zone objects
+  ensureZoneZOrder(context);
+
   context.app.renderer.render(context.app.stage);
 }
 
@@ -132,6 +135,9 @@ export function handleObjectsAdded(
   // After adding, ensure attachment parent visuals render above their children
   ensureAttachmentZOrder(context, message.objects);
 
+  // Zones must always render below all non-zone objects
+  ensureZoneZOrder(context);
+
   context.app.renderer.render(context.app.stage);
 }
 
@@ -152,6 +158,9 @@ export function handleObjectsUpdated(
 
   // After updates, ensure attachment parent visuals render above their children
   ensureAttachmentZOrder(context, message.objects);
+
+  // Zones must always render below all non-zone objects
+  ensureZoneZOrder(context);
 
   context.app.renderer.render(context.app.stage);
 }
@@ -498,6 +507,28 @@ function ensureAttachmentZOrder(
           context.worldContainer.children.length - 1,
         );
       }
+    }
+  }
+}
+
+/**
+ * Helper: Push all zone visuals to the back of the world container.
+ *
+ * Zone-kind objects must always render below every non-zone object.
+ * This is called after any batch add or update that could include zones.
+ * Skips zones currently being dragged — DragManager owns z-order during drag
+ * and will restore them via the next objects-updated sync after drag ends.
+ */
+function ensureZoneZOrder(context: RendererContext): void {
+  const draggedIds = context.drag.getDraggedObjectIds();
+
+  for (const [id, obj] of context.sceneManager.getAllObjects()) {
+    if (obj._kind !== ObjectKind.Zone) continue;
+    // Leave dragged zones alone — DragManager moved them to the top intentionally
+    if (draggedIds.includes(id)) continue;
+    const visual = context.visual.getVisual(id);
+    if (visual && visual.parent === context.worldContainer) {
+      context.worldContainer.setChildIndex(visual, 0);
     }
   }
 }

--- a/app/src/renderer/managers/VisualManager.ts
+++ b/app/src/renderer/managers/VisualManager.ts
@@ -295,6 +295,12 @@ export class VisualManager {
 
     // Add to world container
     worldContainer.addChild(visual);
+
+    // Zones must always render below all non-zone objects.
+    // Move zone visuals to the back of the container immediately after adding.
+    if (obj._kind === ObjectKind.Zone) {
+      worldContainer.setChildIndex(visual, 0);
+    }
   }
 
   /**

--- a/app/src/renderer/objects/zone/behaviors.test.ts
+++ b/app/src/renderer/objects/zone/behaviors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectKind, type TableObject } from '@cardtable2/shared';
+import { isDiscardZone } from './utils';
+import { ZONE_DEFAULT_WIDTH, ZONE_DEFAULT_HEIGHT } from './constants';
+import { ZoneBehaviors } from './behaviors';
+
+function createTestZone(meta?: Record<string, unknown>): TableObject {
+  return {
+    _kind: ObjectKind.Zone,
+    _pos: { x: 0, y: 0, r: 0 },
+    _containerId: null,
+    _sortKey: '0',
+    _locked: false,
+    _selectedBy: null,
+    _meta: meta ?? {},
+  };
+}
+
+describe('isDiscardZone', () => {
+  it('returns false for a plain zone with no _meta', () => {
+    const zone = createTestZone();
+    expect(isDiscardZone(zone)).toBe(false);
+  });
+
+  it('returns false when _meta.isDiscardZone is absent', () => {
+    const zone = createTestZone({ color: 0xff0000 });
+    expect(isDiscardZone(zone)).toBe(false);
+  });
+
+  it('returns false when _meta.isDiscardZone is false', () => {
+    const zone = createTestZone({ isDiscardZone: false });
+    expect(isDiscardZone(zone)).toBe(false);
+  });
+
+  it('returns true when _meta.isDiscardZone is true', () => {
+    const zone = createTestZone({ isDiscardZone: true });
+    expect(isDiscardZone(zone)).toBe(true);
+  });
+});
+
+describe('ZoneBehaviors.getBounds', () => {
+  it('returns centered rect for a plain zone', () => {
+    const zone = createTestZone();
+    const bounds = ZoneBehaviors.getBounds(zone);
+    expect(bounds.minX).toBe(-ZONE_DEFAULT_WIDTH / 2);
+    expect(bounds.maxX).toBe(ZONE_DEFAULT_WIDTH / 2);
+    expect(bounds.minY).toBe(-ZONE_DEFAULT_HEIGHT / 2);
+    expect(bounds.maxY).toBe(ZONE_DEFAULT_HEIGHT / 2);
+  });
+
+  it('returns centered rect for a discard zone (same dimensions)', () => {
+    const zone = createTestZone({ isDiscardZone: true });
+    const bounds = ZoneBehaviors.getBounds(zone);
+    expect(bounds.minX).toBe(-ZONE_DEFAULT_WIDTH / 2);
+    expect(bounds.maxX).toBe(ZONE_DEFAULT_WIDTH / 2);
+    expect(bounds.minY).toBe(-ZONE_DEFAULT_HEIGHT / 2);
+    expect(bounds.maxY).toBe(ZONE_DEFAULT_HEIGHT / 2);
+  });
+});
+
+describe('ZoneBehaviors.capabilities', () => {
+  it('disallows flip/rotate/stack/unstack, allows lock', () => {
+    expect(ZoneBehaviors.capabilities).toEqual({
+      canFlip: false,
+      canRotate: false,
+      canStack: false,
+      canUnstack: false,
+      canLock: true,
+    });
+  });
+});

--- a/app/src/renderer/objects/zone/behaviors.test.ts
+++ b/app/src/renderer/objects/zone/behaviors.test.ts
@@ -56,6 +56,15 @@ describe('ZoneBehaviors.getBounds', () => {
     expect(bounds.minY).toBe(-ZONE_DEFAULT_HEIGHT / 2);
     expect(bounds.maxY).toBe(ZONE_DEFAULT_HEIGHT / 2);
   });
+
+  it('uses custom width/height from meta when present', () => {
+    const zone = createTestZone({ isDiscardZone: true, width: 71, height: 96 });
+    const bounds = ZoneBehaviors.getBounds(zone);
+    expect(bounds.minX).toBe(-71 / 2);
+    expect(bounds.maxX).toBe(71 / 2);
+    expect(bounds.minY).toBe(-96 / 2);
+    expect(bounds.maxY).toBe(96 / 2);
+  });
 });
 
 describe('ZoneBehaviors.capabilities', () => {

--- a/app/src/renderer/objects/zone/behaviors.ts
+++ b/app/src/renderer/objects/zone/behaviors.ts
@@ -5,31 +5,44 @@ import {
   ZONE_FILL_ALPHA,
   ZONE_BORDER_COLOR_NORMAL,
   ZONE_BORDER_COLOR_SELECTED,
+  ZONE_DISCARD_BORDER_COLOR,
+  ZONE_DISCARD_FILL_COLOR,
+  ZONE_DISCARD_FILL_ALPHA,
 } from './constants';
-import { getZoneColor, getZoneWidth, getZoneHeight } from './utils';
+import {
+  getZoneColor,
+  getZoneWidth,
+  getZoneHeight,
+  isDiscardZone,
+} from './utils';
 
 export const ZoneBehaviors: ObjectBehaviors = {
   render(obj: TableObject, ctx: RenderContext): Container {
     const container = new Container();
     const graphic = new Graphics();
-    const color = getZoneColor(obj);
+    const discard = isDiscardZone(obj);
+    const fillColor = discard ? ZONE_DISCARD_FILL_COLOR : getZoneColor(obj);
+    const fillAlpha = discard ? ZONE_DISCARD_FILL_ALPHA : ZONE_FILL_ALPHA;
     const width = getZoneWidth(obj);
     const height = getZoneHeight(obj);
 
     graphic.rect(-width / 2, -height / 2, width, height);
-    graphic.fill({ color, alpha: ZONE_FILL_ALPHA });
+    graphic.fill({ color: fillColor, alpha: fillAlpha });
     graphic.stroke({
       width: ctx.isSelected ? 4 : 2,
       color: ctx.isSelected
         ? ZONE_BORDER_COLOR_SELECTED
-        : ZONE_BORDER_COLOR_NORMAL,
+        : discard
+          ? ZONE_DISCARD_BORDER_COLOR
+          : ZONE_BORDER_COLOR_NORMAL,
     });
 
     container.addChild(graphic);
 
     // Add kind label text (unless in minimal mode)
     if (!ctx.minimal) {
-      const text = ctx.createKindLabel(obj._kind);
+      const label = discard ? 'Discard' : obj._kind;
+      const text = ctx.createKindLabel(label);
       text.anchor.set(0.5);
       text.position.set(0, 0);
       container.addChild(text);

--- a/app/src/renderer/objects/zone/constants.ts
+++ b/app/src/renderer/objects/zone/constants.ts
@@ -7,3 +7,8 @@ export const ZONE_DEFAULT_GRID_SIZE = 50;
 /** Border colors */
 export const ZONE_BORDER_COLOR_NORMAL = 0x2d3436; // Dark gray
 export const ZONE_BORDER_COLOR_SELECTED = 0xef4444; // Red
+
+/** Discard zone visual overrides */
+export const ZONE_DISCARD_BORDER_COLOR = 0xe17055; // Warm orange — distinguishes from plain zone
+export const ZONE_DISCARD_FILL_COLOR = 0xe17055;
+export const ZONE_DISCARD_FILL_ALPHA = 0.15;

--- a/app/src/renderer/objects/zone/utils.ts
+++ b/app/src/renderer/objects/zone/utils.ts
@@ -33,5 +33,5 @@ export function shouldSnapToGrid(obj: TableObject): boolean {
 
 /** True when the zone was created as a discard zone (flag stamped by createDiscardZoneForStack). */
 export function isDiscardZone(obj: TableObject): boolean {
-  return (obj._meta)?.isDiscardZone === true;
+  return obj._meta?.isDiscardZone === true;
 }

--- a/app/src/renderer/objects/zone/utils.ts
+++ b/app/src/renderer/objects/zone/utils.ts
@@ -30,3 +30,8 @@ export function getGridSize(obj: TableObject): number {
 export function shouldSnapToGrid(obj: TableObject): boolean {
   return (obj._meta?.snapToGrid as boolean) ?? true;
 }
+
+/** True when the zone was created as a discard zone (flag stamped by createDiscardZoneForStack). */
+export function isDiscardZone(obj: TableObject): boolean {
+  return (obj._meta)?.isDiscardZone === true;
+}

--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -3411,7 +3411,7 @@ describe('createDiscardZoneForStack', () => {
     expect(store.getDiscardZone(newZoneId!)).toBeDefined();
   });
 
-  it('places the zone to the right of the source stack', () => {
+  it('places the zone immediately to the right of the source stack', () => {
     const stackId = createObject(store, {
       kind: ObjectKind.Stack,
       pos: { x: 200, y: 300, r: 0 },
@@ -3422,14 +3422,34 @@ describe('createDiscardZoneForStack', () => {
     const newZoneId = createDiscardZoneForStack(store, stackId);
     expect(newZoneId).not.toBeNull();
 
-    const zonePos = store.getObjectYMap(newZoneId!)!.get('_pos') as {
-      x: number;
-      y: number;
-      r: number;
-    };
-    expect(zonePos.x).toBeGreaterThan(200);
+    const zoneYMap = store.getObjectYMap(newZoneId!)!;
+    const zonePos = zoneYMap.get('_pos') as { x: number; y: number; r: number };
+
+    // Zone center = stack center + CARD_WIDTH/2 + gap + DISCARD_ZONE_WIDTH/2
+    // CARD_WIDTH=63, gap=8, DISCARD_ZONE_WIDTH=71 → offset=75
+    expect(zonePos.x).toBe(275);
     expect(zonePos.y).toBe(300);
     expect(zonePos.r).toBe(0);
+  });
+
+  it('creates a discard zone with card-sized dimensions in meta', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    const meta = store.getObjectYMap(newZoneId!)!.get('_meta') as Record<
+      string,
+      unknown
+    >;
+    // CARD_WIDTH=63+8=71, CARD_HEIGHT=88+8=96
+    expect(meta.width).toBe(71);
+    expect(meta.height).toBe(96);
   });
 
   it('snapshot is independent of subsequent stack mutations', () => {
@@ -3631,6 +3651,79 @@ describe('discardCardToZone', () => {
     expect(cards).toContain('card-1');
     expect(cards).toContain('card-2');
     expect(cards.length).toBe(2);
+  });
+
+  it('discard → drag out → discard re-routes to pile (not flip)', () => {
+    // Reproduce the "X just flips" bug: after discard then drag-out, pressing X
+    // should re-discard (move card back to pile), not merely set _faceUp=true.
+    const { stackId, zoneId } = setupSourceAndZone(['card-1']);
+
+    // First discard: card-1 moves to zone, gets _containerId=zoneId
+    expect(discardCardToZone(store, 'card-1')).toBe(true);
+
+    // Pile exists in zone
+    const pileAfterDiscard = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileAfterDiscard.length).toBe(1);
+    const pileId = pileAfterDiscard[0];
+
+    // Simulate drag-out: user moves the pile stack to a new position via moveObjects.
+    // This must clear _containerId so the card is no longer "in" the zone.
+    moveObjects(store, [{ id: pileId, pos: { x: 300, y: 300, r: 0 } }]);
+
+    // After drag-out, _containerId must be cleared
+    expect(store.getObjectYMap(pileId)!.get('_containerId')).toBeNull();
+
+    // No pile should exist in zone after drag-out
+    const pileAfterDragOut = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileAfterDragOut.length).toBe(0);
+
+    // Second discard: must re-route to zone, NOT just flip the card in place
+    expect(discardCardToZone(store, 'card-1')).toBe(true);
+
+    const pileAfterRediscard = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileAfterRediscard.length).toBe(1);
+    const cards = store
+      .getObjectYMap(pileAfterRediscard[0])!
+      .get('_cards') as string[];
+    expect(cards).toContain('card-1');
+    // Card must be face-up after discard
+    expect(store.getObjectYMap(pileAfterRediscard[0])!.get('_faceUp')).toBe(
+      true,
+    );
+
+    // stackId was a single-card stack; after discard the stack itself becomes the pile
+    void stackId;
+  });
+
+  it('moveObjects clears _containerId on moved objects', () => {
+    // Unit test for the _containerId-clear side-effect in moveObjects.
+    const { stackId, zoneId } = setupSourceAndZone(['card-1']);
+    discardCardToZone(store, 'card-1');
+
+    // card-1's stack (which may be the original stackId or a new pile id) should have _containerId
+    const pileIds = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileIds.length).toBe(1);
+    const pileId = pileIds[0];
+
+    moveObjects(store, [{ id: pileId, pos: { x: 999, y: 999, r: 0 } }]);
+    expect(store.getObjectYMap(pileId)!.get('_containerId')).toBeNull();
+    void stackId;
   });
 
   it('card extracted from a foreign stack routes to home zone', () => {

--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -17,12 +17,14 @@ import {
   detachAllCards,
   resetTable,
   adjustCounter,
+  createDiscardZoneForStack,
 } from './YjsActions';
 import {
   ObjectKind,
   type StackObject,
   type TableObject,
   parseSortKeyPrefix,
+  type DiscardZoneEntry,
 } from '@cardtable2/shared';
 
 // Mock y-indexeddb to avoid IndexedDB in tests
@@ -3323,5 +3325,142 @@ describe('YjsActions - adjustCounter (ct-d2p)', () => {
       startingValue: 3,
       currentValue: 5,
     });
+  });
+});
+
+describe('createDiscardZoneForStack', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-discard-zone-table');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    if (store) {
+      store.destroy();
+    }
+  });
+
+  it('returns null for a missing stack id', () => {
+    const result = createDiscardZoneForStack(store, 'nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the id is not a stack', () => {
+    const zoneId = createObject(store, {
+      kind: ObjectKind.Zone,
+      pos: { x: 0, y: 0, r: 0 },
+    });
+
+    const result = createDiscardZoneForStack(store, zoneId);
+    expect(result).toBeNull();
+  });
+
+  it('creates a Zone object with _meta.isDiscardZone true', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 100, y: 100, r: 0 },
+      cards: ['card-1', 'card-2'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    const zoneYMap = store.getObjectYMap(newZoneId!);
+    expect(zoneYMap).toBeDefined();
+    expect(zoneYMap!.get('_kind')).toBe(ObjectKind.Zone);
+
+    const meta = zoneYMap!.get('_meta') as Record<string, unknown>;
+    expect(meta.isDiscardZone).toBe(true);
+  });
+
+  it('snapshots member card ids matching the stack _cards at creation time', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-a', 'card-b', 'card-c', 'card-d', 'card-e'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    const entry = store.getDiscardZone(newZoneId!) as DiscardZoneEntry;
+    expect(entry).toBeDefined();
+    expect(new Set(entry.memberCardIds)).toEqual(
+      new Set(['card-a', 'card-b', 'card-c', 'card-d', 'card-e']),
+    );
+    expect(entry.memberCardIds).toHaveLength(5);
+  });
+
+  it('writes a DiscardZoneEntry keyed by the new zone id', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 50, y: 50, r: 0 },
+      cards: ['card-1'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    expect(store.getDiscardZone(newZoneId!)).toBeDefined();
+  });
+
+  it('places the zone to the right of the source stack', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 200, y: 300, r: 0 },
+      cards: ['card-1'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    const zonePos = store.getObjectYMap(newZoneId!)!.get('_pos') as {
+      x: number;
+      y: number;
+      r: number;
+    };
+    expect(zonePos.x).toBeGreaterThan(200);
+    expect(zonePos.y).toBe(300);
+    expect(zonePos.r).toBe(0);
+  });
+
+  it('snapshot is independent of subsequent stack mutations', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1', 'card-2'],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    // Mutate the source stack after zone creation
+    store.getObjectYMap(stackId)!.set('_cards', ['card-1', 'card-2', 'card-3']);
+
+    const entry = store.getDiscardZone(newZoneId!) as DiscardZoneEntry;
+    expect(entry.memberCardIds).toHaveLength(2);
+    expect(entry.memberCardIds).not.toContain('card-3');
+  });
+
+  it('creates a zone with empty memberCardIds for an empty stack', () => {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: [],
+      faceUp: true,
+    });
+
+    const newZoneId = createDiscardZoneForStack(store, stackId);
+    expect(newZoneId).not.toBeNull();
+
+    const entry = store.getDiscardZone(newZoneId!) as DiscardZoneEntry;
+    expect(entry.memberCardIds).toEqual([]);
   });
 });

--- a/app/src/store/YjsActions.test.ts
+++ b/app/src/store/YjsActions.test.ts
@@ -18,6 +18,8 @@ import {
   resetTable,
   adjustCounter,
   createDiscardZoneForStack,
+  setCardFaceUp,
+  discardCardToZone,
 } from './YjsActions';
 import {
   ObjectKind,
@@ -3462,5 +3464,214 @@ describe('createDiscardZoneForStack', () => {
 
     const entry = store.getDiscardZone(newZoneId!) as DiscardZoneEntry;
     expect(entry.memberCardIds).toEqual([]);
+  });
+});
+
+describe('setCardFaceUp', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-setcardface-table');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    store.destroy();
+  });
+
+  it('sets a face-down stack to face-up', () => {
+    const id = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1'],
+      faceUp: false,
+    });
+
+    const result = setCardFaceUp(store, id, true);
+    expect(result).toBe(true);
+    expect(store.getObjectYMap(id)!.get('_faceUp')).toBe(true);
+  });
+
+  it('sets a face-up stack to face-down', () => {
+    const id = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1'],
+      faceUp: true,
+    });
+
+    const result = setCardFaceUp(store, id, false);
+    expect(result).toBe(true);
+    expect(store.getObjectYMap(id)!.get('_faceUp')).toBe(false);
+  });
+
+  it('is idempotent: calling twice with same value leaves state unchanged', () => {
+    const id = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-1'],
+      faceUp: false,
+    });
+
+    setCardFaceUp(store, id, true);
+    setCardFaceUp(store, id, true);
+    expect(store.getObjectYMap(id)!.get('_faceUp')).toBe(true);
+  });
+
+  it('returns false for a missing object', () => {
+    expect(setCardFaceUp(store, 'nonexistent', true)).toBe(false);
+  });
+
+  it('returns false for a non-Stack object', () => {
+    const id = createObject(store, {
+      kind: ObjectKind.Zone,
+      pos: { x: 0, y: 0, r: 0 },
+    });
+    expect(setCardFaceUp(store, id, true)).toBe(false);
+  });
+});
+
+describe('discardCardToZone', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-discardcard-table');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    store.destroy();
+  });
+
+  function setupSourceAndZone(cards: string[], faceUp = false) {
+    const stackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 100, y: 100, r: 0 },
+      cards,
+      faceUp,
+    });
+    const zoneId = createDiscardZoneForStack(store, stackId)!;
+    return { stackId, zoneId };
+  }
+
+  it('returns false when the card has no home zone', () => {
+    createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['orphan-card'],
+      faceUp: false,
+    });
+    expect(discardCardToZone(store, 'orphan-card')).toBe(false);
+  });
+
+  it('returns false for a card not found in any stack', () => {
+    const { zoneId } = setupSourceAndZone(['card-1']);
+    void zoneId;
+    // 'card-99' is a member of zone but doesn't exist in any stack
+    store.setDiscardZone('fake-zone', { memberCardIds: ['card-99'] });
+    expect(discardCardToZone(store, 'card-99')).toBe(false);
+  });
+
+  it('routes a single-card stack to an empty zone (new pile path)', () => {
+    const { stackId, zoneId } = setupSourceAndZone(['card-1']);
+
+    const result = discardCardToZone(store, 'card-1');
+    expect(result).toBe(true);
+
+    // Original stack should be gone (or at least card-1 is in the zone)
+    void stackId;
+
+    // There must be a Stack with _containerId === zoneId
+    const pileIds = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileIds.length).toBe(1);
+
+    const pileYMap = store.getObjectYMap(pileIds[0])!;
+    const cards = pileYMap.get('_cards') as string[];
+    expect(cards).toContain('card-1');
+    expect(pileYMap.get('_faceUp')).toBe(true);
+  });
+
+  it('face-down card lands face-up in the zone', () => {
+    const { zoneId } = setupSourceAndZone(['card-face-down'], false);
+
+    discardCardToZone(store, 'card-face-down');
+
+    const pileIds = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileIds.length).toBe(1);
+    expect(store.getObjectYMap(pileIds[0])!.get('_faceUp')).toBe(true);
+  });
+
+  it('second discard merges onto the existing pile (merge path)', () => {
+    const { zoneId } = setupSourceAndZone(['card-1', 'card-2']);
+
+    discardCardToZone(store, 'card-1');
+
+    // Now 'card-2' is top of the source stack; create a second stack for it
+    // Actually card-2 is in the original source stack still. But card-1 was top.
+    // The source stack now has card-2 as its sole remaining card (if it was 2-card).
+    // Discard card-2 — it should merge onto the existing pile.
+    discardCardToZone(store, 'card-2');
+
+    const pileIds = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileIds.length).toBe(1);
+
+    const cards = store.getObjectYMap(pileIds[0])!.get('_cards') as string[];
+    expect(cards).toContain('card-1');
+    expect(cards).toContain('card-2');
+    expect(cards.length).toBe(2);
+  });
+
+  it('card extracted from a foreign stack routes to home zone', () => {
+    // source stack defines zone membership
+    const sourceId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 0, y: 0, r: 0 },
+      cards: ['card-member'],
+      faceUp: true,
+    });
+    const zoneId = createDiscardZoneForStack(store, sourceId)!;
+
+    // Move card-member into a different stack (foreign stack)
+    const foreignStackId = createObject(store, {
+      kind: ObjectKind.Stack,
+      pos: { x: 500, y: 500, r: 0 },
+      cards: ['other-card', 'card-member'],
+      faceUp: false,
+    });
+    // Delete the original source stack (card-member is now in foreign)
+    store.deleteObject(sourceId);
+
+    const result = discardCardToZone(store, 'card-member');
+    expect(result).toBe(true);
+
+    // Foreign stack should be smaller (card-member extracted)
+    const foreignYMap = store.getObjectYMap(foreignStackId);
+    if (foreignYMap) {
+      const remainingCards = foreignYMap.get('_cards') as string[];
+      expect(remainingCards).not.toContain('card-member');
+    }
+
+    // card-member is now in the zone's pile
+    const pileIds = store.filterObjects(
+      (yMap) =>
+        yMap.get('_kind') === ObjectKind.Stack &&
+        yMap.get('_containerId') === zoneId,
+    );
+    expect(pileIds.length).toBe(1);
+    const cards = store.getObjectYMap(pileIds[0])!.get('_cards') as string[];
+    expect(cards).toContain('card-member');
+    expect(store.getObjectYMap(pileIds[0])!.get('_faceUp')).toBe(true);
   });
 });

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1223,6 +1223,169 @@ export function adjustCounter(
   return { newValue: clamped, clamped: false };
 }
 
+/**
+ * Set a stack's face-up state to an explicit value (idempotent).
+ *
+ * Unlike flipCards which toggles, this sets _faceUp unconditionally.
+ * Cards discarded to a zone always land face-up regardless of prior state.
+ *
+ * @param store - YjsStore instance
+ * @param id - Stack object ID
+ * @param faceUp - Desired face-up state
+ * @returns true if the update was applied, false if the object was missing or not a Stack
+ */
+export function setCardFaceUp(
+  store: YjsStore,
+  id: string,
+  faceUp: boolean,
+): boolean {
+  const yMap = store.getObjectYMap(id);
+  if (!yMap) {
+    console.warn(`[setCardFaceUp] Object ${id} not found`);
+    return false;
+  }
+  if (yMap.get('_kind') !== ObjectKind.Stack) {
+    console.warn(`[setCardFaceUp] Object ${id} is not a Stack`);
+    return false;
+  }
+  store.getDoc().transact(() => {
+    yMap.set('_faceUp', faceUp);
+  });
+  return true;
+}
+
+/**
+ * Find the existing pile Stack inside a discard zone.
+ *
+ * Scans all objects for a Stack whose _containerId equals zoneId.
+ * Returns the pile's object ID, or null if none exists yet.
+ */
+function findZonePile(store: YjsStore, zoneId: string): string | null {
+  let pileId: string | null = null;
+  store.forEachObject((yMap, id) => {
+    if (
+      pileId === null &&
+      yMap.get('_kind') === ObjectKind.Stack &&
+      yMap.get('_containerId') === zoneId
+    ) {
+      pileId = id;
+    }
+  });
+  return pileId;
+}
+
+/**
+ * Route a single card to its home discard zone.
+ *
+ * Steps (all in one transaction):
+ * 1. Resolve the card's home zone via findDiscardZoneForCard.
+ * 2. Extract the card from its current stack (if multi-card, unstack top card;
+ *    if single-card stack, use as-is). v1: operates on the top card of whatever
+ *    stack the card currently occupies — arbitrary middle extraction is deferred.
+ * 3. Set the extracted stack face-up.
+ * 4. Merge into the zone's existing pile (stackObjects) or move to zone and set
+ *    _containerId.
+ *
+ * @param store - YjsStore instance
+ * @param cardId - Card ID (not stack ID — looked up by membership)
+ * @returns true if routed successfully, false if card has no home zone or is not found
+ */
+export function discardCardToZone(store: YjsStore, cardId: string): boolean {
+  const zoneId = store.findDiscardZoneForCard(cardId);
+  if (!zoneId) {
+    console.warn(`[discardCardToZone] Card ${cardId} has no home zone`);
+    return false;
+  }
+
+  // Find which stack currently holds this card
+  let sourceStackId: string | null = null;
+  let cardIsTopOfSource = false;
+
+  store.forEachObject((yMap, id) => {
+    if (sourceStackId !== null) return;
+    if (yMap.get('_kind') !== ObjectKind.Stack) return;
+    const cards = yMap.get('_cards');
+    if (!cards) return;
+    const idx = cards.indexOf(cardId);
+    if (idx !== -1) {
+      sourceStackId = id;
+      cardIsTopOfSource = idx === 0;
+    }
+  });
+
+  if (!sourceStackId) {
+    console.warn(`[discardCardToZone] Card ${cardId} not found in any stack`);
+    return false;
+  }
+
+  const zoneYMap = store.getObjectYMap(zoneId);
+  if (!zoneYMap) {
+    console.warn(`[discardCardToZone] Zone ${zoneId} not found`);
+    return false;
+  }
+  const zonePos = zoneYMap.get('_pos') as { x: number; y: number; r: number };
+
+  const sourceCards = store
+    .getObjectYMap(sourceStackId)!
+    .get('_cards') as string[];
+  const isSingleCardStack = sourceCards.length === 1;
+
+  let extractedStackId: string | null = null;
+
+  store.getDoc().transact(() => {
+    if (isSingleCardStack) {
+      // Already a single-card stack — use it directly
+      extractedStackId = sourceStackId;
+    } else if (cardIsTopOfSource) {
+      // Top card: unstack it to zone position (position will be overridden below)
+      extractedStackId = unstackCard(store, sourceStackId!, {
+        x: zonePos.x,
+        y: zonePos.y,
+        r: 0,
+      });
+    } else {
+      // Card is not on top — swap it to top by rewriting the _cards array, then unstack
+      const sourceYMap = store.getObjectYMap(sourceStackId!)!;
+      const cards = sourceYMap.get('_cards') as string[];
+      const idx = cards.indexOf(cardId);
+      const reordered = [cardId, ...cards.filter((c) => c !== cardId)];
+      sourceYMap.set('_cards', reordered);
+      // idx is guaranteed > 0 here
+      void idx;
+      extractedStackId = unstackCard(store, sourceStackId!, {
+        x: zonePos.x,
+        y: zonePos.y,
+        r: 0,
+      });
+    }
+
+    if (!extractedStackId) return;
+
+    // Ensure the extracted stack is face-up
+    const extractedYMap = store.getObjectYMap(extractedStackId)!;
+    extractedYMap.set('_faceUp', true);
+
+    const existingPileId = findZonePile(store, zoneId);
+
+    if (existingPileId && existingPileId !== extractedStackId) {
+      // Ensure the pile is face-up (stackObjects target state wins)
+      const pileYMap = store.getObjectYMap(existingPileId);
+      if (pileYMap) {
+        pileYMap.set('_faceUp', true);
+      }
+      // Merge extracted stack onto the pile
+      stackObjects(store, [extractedStackId], existingPileId);
+      // stackObjects deletes the source; the pile retains its _containerId
+    } else {
+      // No existing pile — move extracted stack into zone and mark it
+      moveObjects(store, [{ id: extractedStackId, pos: zonePos }]);
+      extractedYMap.set('_containerId', zoneId);
+    }
+  });
+
+  return extractedStackId !== null;
+}
+
 // Horizontal offset applied when placing a discard zone relative to its source
 // stack. 420 world-units clears the default zone width (400) with a small gap.
 // v1 hardcoded — ct-rdu tracks user-positioned placement.
@@ -1259,7 +1422,7 @@ export function createDiscardZoneForStack(
     return null;
   }
 
-  const sourceCards = (sourceYMap.get('_cards')) ?? [];
+  const sourceCards = sourceYMap.get('_cards') ?? [];
   const sourcePos = sourceYMap.get('_pos') as Position;
 
   let newZoneId: string | null = null;

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -1297,27 +1297,6 @@ export function discardCardToZone(store: YjsStore, cardId: string): boolean {
     return false;
   }
 
-  // Find which stack currently holds this card
-  let sourceStackId: string | null = null;
-  let cardIsTopOfSource = false;
-
-  store.forEachObject((yMap, id) => {
-    if (sourceStackId !== null) return;
-    if (yMap.get('_kind') !== ObjectKind.Stack) return;
-    const cards = yMap.get('_cards');
-    if (!cards) return;
-    const idx = cards.indexOf(cardId);
-    if (idx !== -1) {
-      sourceStackId = id;
-      cardIsTopOfSource = idx === 0;
-    }
-  });
-
-  if (!sourceStackId) {
-    console.warn(`[discardCardToZone] Card ${cardId} not found in any stack`);
-    return false;
-  }
-
   const zoneYMap = store.getObjectYMap(zoneId);
   if (!zoneYMap) {
     console.warn(`[discardCardToZone] Zone ${zoneId} not found`);
@@ -1325,34 +1304,52 @@ export function discardCardToZone(store: YjsStore, cardId: string): boolean {
   }
   const zonePos = zoneYMap.get('_pos') as { x: number; y: number; r: number };
 
-  const sourceCards = store
-    .getObjectYMap(sourceStackId)!
-    .get('_cards') as string[];
-  const isSingleCardStack = sourceCards.length === 1;
-
   let extractedStackId: string | null = null;
 
   store.getDoc().transact(() => {
+    // Find which stack currently holds this card (read inside transaction for consistency)
+    let sourceStackId: string | null = null;
+    let cardIsTopOfSource = false;
+
+    store.forEachObject((yMap, id) => {
+      if (sourceStackId !== null) return;
+      if (yMap.get('_kind') !== ObjectKind.Stack) return;
+      const cards = yMap.get('_cards');
+      if (!cards) return;
+      const idx = cards.indexOf(cardId);
+      if (idx !== -1) {
+        sourceStackId = id;
+        cardIsTopOfSource = idx === 0;
+      }
+    });
+
+    if (!sourceStackId) {
+      console.warn(`[discardCardToZone] Card ${cardId} not found in any stack`);
+      return;
+    }
+
+    const sourceCards = store
+      .getObjectYMap(sourceStackId)!
+      .get('_cards') as string[];
+    const isSingleCardStack = sourceCards.length === 1;
+
     if (isSingleCardStack) {
       // Already a single-card stack — use it directly
       extractedStackId = sourceStackId;
     } else if (cardIsTopOfSource) {
       // Top card: unstack it to zone position (position will be overridden below)
-      extractedStackId = unstackCard(store, sourceStackId!, {
+      extractedStackId = unstackCard(store, sourceStackId, {
         x: zonePos.x,
         y: zonePos.y,
         r: 0,
       });
     } else {
       // Card is not on top — swap it to top by rewriting the _cards array, then unstack
-      const sourceYMap = store.getObjectYMap(sourceStackId!)!;
+      const sourceYMap = store.getObjectYMap(sourceStackId)!;
       const cards = sourceYMap.get('_cards') as string[];
-      const idx = cards.indexOf(cardId);
       const reordered = [cardId, ...cards.filter((c) => c !== cardId)];
       sourceYMap.set('_cards', reordered);
-      // idx is guaranteed > 0 here
-      void idx;
-      extractedStackId = unstackCard(store, sourceStackId!, {
+      extractedStackId = unstackCard(store, sourceStackId, {
         x: zonePos.x,
         y: zonePos.y,
         r: 0,

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -11,6 +11,7 @@ import {
   sortKeyBase,
   sortKeyWithSub,
   PARENT_ON_TOP_SUB_KEY,
+  type DiscardZoneEntry,
 } from '@cardtable2/shared';
 import { getDefaultMeta, getDefaultProperties } from './ObjectDefaults';
 import { createCounterMeta } from '../renderer/objects/counter/utils';
@@ -1220,6 +1221,62 @@ export function adjustCounter(
   });
 
   return { newValue: clamped, clamped: false };
+}
+
+// Horizontal offset applied when placing a discard zone relative to its source
+// stack. 420 world-units clears the default zone width (400) with a small gap.
+// v1 hardcoded — ct-rdu tracks user-positioned placement.
+const DISCARD_ZONE_X_OFFSET = 420;
+
+/**
+ * Atomically create a discard zone for a stack and snapshot its membership.
+ *
+ * Creates a Zone object offset to the right of the source stack and writes a
+ * DiscardZoneEntry whose memberCardIds is a point-in-time snapshot of the
+ * stack's _cards array. Both the zone object and the membership entry land in
+ * a single doc.transact() so no partial state is visible to peers.
+ *
+ * @param store - YjsStore instance
+ * @param sourceStackId - ID of the stack to create a discard zone for
+ * @returns The new zone's ID, or null if the source is missing or not a stack
+ */
+export function createDiscardZoneForStack(
+  store: YjsStore,
+  sourceStackId: string,
+): string | null {
+  const sourceYMap = store.getObjectYMap(sourceStackId);
+  if (!sourceYMap) {
+    console.warn(
+      `[createDiscardZoneForStack] Stack ${sourceStackId} not found`,
+    );
+    return null;
+  }
+
+  if (sourceYMap.get('_kind') !== ObjectKind.Stack) {
+    console.warn(
+      `[createDiscardZoneForStack] Object ${sourceStackId} is not a stack`,
+    );
+    return null;
+  }
+
+  const sourceCards = (sourceYMap.get('_cards')) ?? [];
+  const sourcePos = sourceYMap.get('_pos') as Position;
+
+  let newZoneId: string | null = null;
+
+  store.getDoc().transact(() => {
+    const zoneId = createObject(store, {
+      kind: ObjectKind.Zone,
+      pos: { x: sourcePos.x + DISCARD_ZONE_X_OFFSET, y: sourcePos.y, r: 0 },
+      meta: { label: 'Discard', isDiscardZone: true },
+    });
+
+    const entry: DiscardZoneEntry = { memberCardIds: [...sourceCards] };
+    store.setDiscardZone(zoneId, entry);
+    newZoneId = zoneId;
+  });
+
+  return newZoneId;
 }
 
 /**

--- a/app/src/store/YjsActions.ts
+++ b/app/src/store/YjsActions.ts
@@ -17,6 +17,7 @@ import { getDefaultMeta, getDefaultProperties } from './ObjectDefaults';
 import { createCounterMeta } from '../renderer/objects/counter/utils';
 import type { CounterMeta } from '../renderer/objects/counter/types';
 import { computeAttachmentPositions } from './attachmentLayout';
+import { CARD_WIDTH, CARD_HEIGHT } from '../renderer/constants';
 
 /**
  * Engine Actions for Yjs-based state manipulation (M3-T2)
@@ -200,6 +201,16 @@ export function moveObjects(
 
       // Update position directly on Y.Map
       yMap.set('_pos', pos);
+
+      // Clear discard-pile membership when the object is manually moved.
+      // A card dragged out of a zone is no longer resting in its pile; discarding
+      // again must re-form the pile rather than treating the card as still there.
+      // discardCardToZone sets _containerId AFTER calling moveObjects, so clearing
+      // here is safe for the new-pile branch (it re-sets the value immediately after).
+      const currentContainerId = yMap.get('_containerId');
+      if (currentContainerId) {
+        yMap.set('_containerId', null);
+      }
 
       // Update sortKey: preserve attachment sub-key structure, replace base prefix
       if (movedIds.has(id)) {
@@ -1383,10 +1394,17 @@ export function discardCardToZone(store: YjsStore, cardId: string): boolean {
   return extractedStackId !== null;
 }
 
-// Horizontal offset applied when placing a discard zone relative to its source
-// stack. 420 world-units clears the default zone width (400) with a small gap.
-// v1 hardcoded — ct-rdu tracks user-positioned placement.
-const DISCARD_ZONE_X_OFFSET = 420;
+// Discard zone dimensions: slightly larger than a single card.
+const DISCARD_ZONE_WIDTH = CARD_WIDTH + 8; // 71 world-units
+const DISCARD_ZONE_HEIGHT = CARD_HEIGHT + 8; // 96 world-units
+
+// Gap between the source stack's right edge and the zone's left edge.
+const DISCARD_ZONE_GAP = 8;
+
+// X offset from source stack center to discard zone center:
+//   stack right edge + gap + half zone width
+const DISCARD_ZONE_X_OFFSET =
+  CARD_WIDTH / 2 + DISCARD_ZONE_GAP + DISCARD_ZONE_WIDTH / 2;
 
 /**
  * Atomically create a discard zone for a stack and snapshot its membership.
@@ -1428,7 +1446,12 @@ export function createDiscardZoneForStack(
     const zoneId = createObject(store, {
       kind: ObjectKind.Zone,
       pos: { x: sourcePos.x + DISCARD_ZONE_X_OFFSET, y: sourcePos.y, r: 0 },
-      meta: { label: 'Discard', isDiscardZone: true },
+      meta: {
+        label: 'Discard',
+        isDiscardZone: true,
+        width: DISCARD_ZONE_WIDTH,
+        height: DISCARD_ZONE_HEIGHT,
+      },
     });
 
     const entry: DiscardZoneEntry = { memberCardIds: [...sourceCards] };

--- a/app/src/store/YjsDiscardZoneActions.test.ts
+++ b/app/src/store/YjsDiscardZoneActions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as Y from 'yjs';
+import { YjsStore } from './YjsStore';
+import type { DiscardZoneEntry } from '@cardtable2/shared';
+
+// Mock y-indexeddb to avoid IndexedDB in tests
+vi.mock('y-indexeddb', () => ({
+  IndexeddbPersistence: class MockIndexeddbPersistence {
+    private listeners: Map<string, Array<() => void>> = new Map();
+
+    constructor(_dbName: string, _doc: unknown) {
+      setTimeout(() => {
+        const syncedListeners = this.listeners.get('synced') || [];
+        syncedListeners.forEach((listener) => listener());
+      }, 0);
+    }
+
+    on(event: string, listener: () => void) {
+      if (!this.listeners.has(event)) {
+        this.listeners.set(event, []);
+      }
+      this.listeners.get(event)!.push(listener);
+    }
+
+    destroy() {
+      this.listeners.clear();
+    }
+  },
+}));
+
+describe('YjsStore discard zone methods', () => {
+  let store: YjsStore;
+
+  beforeEach(async () => {
+    store = new YjsStore('test-table');
+    await store.waitForReady();
+  });
+
+  afterEach(() => {
+    store.destroy();
+  });
+
+  describe('setDiscardZone / getDiscardZone', () => {
+    it('stores and retrieves an entry', () => {
+      const entry: DiscardZoneEntry = { memberCardIds: ['card-1', 'card-2'] };
+      store.setDiscardZone('zone-a', entry);
+
+      expect(store.getDiscardZone('zone-a')).toEqual(entry);
+    });
+
+    it('returns undefined for an unknown zoneId', () => {
+      expect(store.getDiscardZone('nonexistent')).toBeUndefined();
+    });
+
+    it('overwrites an existing entry', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1', 'card-2'] });
+
+      expect(store.getDiscardZone('zone-a')).toEqual({
+        memberCardIds: ['card-1', 'card-2'],
+      });
+    });
+  });
+
+  describe('deleteDiscardZone', () => {
+    it('removes an existing entry', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+      store.deleteDiscardZone('zone-a');
+
+      expect(store.getDiscardZone('zone-a')).toBeUndefined();
+    });
+
+    it('is a no-op for a nonexistent zoneId', () => {
+      expect(() => store.deleteDiscardZone('nonexistent')).not.toThrow();
+    });
+  });
+
+  describe('getAllDiscardZones', () => {
+    it('returns all entries', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+      store.setDiscardZone('zone-b', { memberCardIds: ['card-2', 'card-3'] });
+
+      const all = store.getAllDiscardZones();
+      expect(all.size).toBe(2);
+      expect(all.get('zone-a')).toEqual({ memberCardIds: ['card-1'] });
+      expect(all.get('zone-b')).toEqual({
+        memberCardIds: ['card-2', 'card-3'],
+      });
+    });
+
+    it('returns empty map when no zones exist', () => {
+      expect(store.getAllDiscardZones().size).toBe(0);
+    });
+  });
+
+  describe('findDiscardZoneForCard', () => {
+    it('returns zoneId when card is a member', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1', 'card-2'] });
+
+      expect(store.findDiscardZoneForCard('card-1')).toBe('zone-a');
+      expect(store.findDiscardZoneForCard('card-2')).toBe('zone-a');
+    });
+
+    it('returns null when card is not in any zone', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+
+      expect(store.findDiscardZoneForCard('card-99')).toBeNull();
+    });
+
+    it('returns null when no zones exist', () => {
+      expect(store.findDiscardZoneForCard('card-1')).toBeNull();
+    });
+
+    it('returns first match when card appears in multiple zones', () => {
+      // This is a degenerate case (ct-u8y tracks disambiguation).
+      // The contract guarantees first-match wins; we verify it doesn't throw.
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-shared'] });
+      store.setDiscardZone('zone-b', { memberCardIds: ['card-shared'] });
+
+      const result = store.findDiscardZoneForCard('card-shared');
+      expect(result === 'zone-a' || result === 'zone-b').toBe(true);
+    });
+  });
+
+  describe('onDiscardZonesChange', () => {
+    it('fires callback when a zone is set', () => {
+      const callback = vi.fn();
+      const unsubscribe = store.onDiscardZonesChange(callback);
+
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+      expect(callback).toHaveBeenCalled();
+
+      unsubscribe();
+    });
+
+    it('fires callback when a zone is deleted', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+
+      const callback = vi.fn();
+      const unsubscribe = store.onDiscardZonesChange(callback);
+
+      store.deleteDiscardZone('zone-a');
+      expect(callback).toHaveBeenCalled();
+
+      unsubscribe();
+    });
+
+    it('stops firing after unsubscribe', () => {
+      const callback = vi.fn();
+      const unsubscribe = store.onDiscardZonesChange(callback);
+      unsubscribe();
+
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1'] });
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('doc serialize / deserialize round-trip', () => {
+    it('survives a Y.Doc encode + apply cycle', () => {
+      store.setDiscardZone('zone-a', { memberCardIds: ['card-1', 'card-2'] });
+      store.setDiscardZone('zone-b', { memberCardIds: ['card-3'] });
+
+      // Encode state from source doc
+      const encoded = Y.encodeStateAsUpdate(store['doc']);
+
+      // Apply into a fresh doc and read back
+      const freshDoc = new Y.Doc();
+      Y.applyUpdate(freshDoc, encoded);
+
+      const freshZones = freshDoc.getMap<DiscardZoneEntry>('discardZones');
+      expect(freshZones.get('zone-a')).toEqual({
+        memberCardIds: ['card-1', 'card-2'],
+      });
+      expect(freshZones.get('zone-b')).toEqual({ memberCardIds: ['card-3'] });
+
+      freshDoc.destroy();
+    });
+  });
+});

--- a/app/src/store/YjsStore.ts
+++ b/app/src/store/YjsStore.ts
@@ -8,6 +8,7 @@ import type {
   ActorId,
   AwarenessState,
   ObjectKind,
+  DiscardZoneEntry,
 } from '@cardtable2/shared';
 import { v4 as uuidv4 } from 'uuid';
 import { throttle, AWARENESS_UPDATE_INTERVAL_MS } from '../utils/throttle';
@@ -71,6 +72,10 @@ export class YjsStore {
   // Player hands map (hand ID -> Y.Map with name, cards, visibility)
   public hands: Y.Map<Y.Map<unknown>>;
 
+  // Discard zones map (zoneId -> DiscardZoneEntry plain object)
+  // getMap auto-creates an empty map for new docs; no migration needed.
+  public discardZones: Y.Map<DiscardZoneEntry>;
+
   // Awareness for ephemeral state (M3-T4)
   public awareness: Awareness;
 
@@ -106,6 +111,9 @@ export class YjsStore {
 
     // Get or create hands map
     this.hands = this.doc.getMap('hands');
+
+    // Get or create discard zones map
+    this.discardZones = this.doc.getMap('discardZones');
 
     // Initialize awareness (M3-T4)
     this.awareness = new Awareness(this.doc);
@@ -840,6 +848,54 @@ export class YjsStore {
     this.hands.observeDeep(observer);
     return () => {
       this.hands.unobserveDeep(observer);
+    };
+  }
+
+  // ============================================================================
+  // Discard Zones Methods
+  // ============================================================================
+
+  setDiscardZone(zoneId: string, entry: DiscardZoneEntry): void {
+    this.doc.transact(() => {
+      this.discardZones.set(zoneId, entry);
+    });
+  }
+
+  getDiscardZone(zoneId: string): DiscardZoneEntry | undefined {
+    return this.discardZones.get(zoneId);
+  }
+
+  deleteDiscardZone(zoneId: string): void {
+    this.doc.transact(() => {
+      this.discardZones.delete(zoneId);
+    });
+  }
+
+  getAllDiscardZones(): Map<string, DiscardZoneEntry> {
+    const result = new Map<string, DiscardZoneEntry>();
+    this.discardZones.forEach((entry, id) => {
+      result.set(id, entry);
+    });
+    return result;
+  }
+
+  findDiscardZoneForCard(cardId: string): string | null {
+    let found: string | null = null;
+    this.discardZones.forEach((entry, zoneId) => {
+      if (found === null && entry.memberCardIds.includes(cardId)) {
+        found = zoneId;
+      }
+    });
+    return found;
+  }
+
+  onDiscardZonesChange(callback: () => void): () => void {
+    const observer = () => {
+      callback();
+    };
+    this.discardZones.observeDeep(observer);
+    return () => {
+      this.discardZones.unobserveDeep(observer);
     };
   }
 

--- a/app/src/store/migrations.ts
+++ b/app/src/store/migrations.ts
@@ -30,6 +30,9 @@ import { getDefaultProperties } from './ObjectDefaults';
  *
  * @param doc - The Yjs document
  */
+// discardZones: Y.Map — added in ct-55s. getMap auto-creates an empty map for
+// new and existing docs, so no migration entry is needed here.
+
 export function runMigrations(doc: Y.Doc): void {
   const objectsMap = doc.getMap('objects');
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -50,6 +50,17 @@ export interface AttachmentData {
 }
 
 // ============================================================================
+// Discard Zone Data
+// ============================================================================
+
+// Membership is keyed by CARD ID (not stack id) because stack ids are minted
+// fresh on every split/merge (YjsActions.ts stackObjects/unstackCard). Card ids
+// are stable across the lifetime of a card object on the table.
+export interface DiscardZoneEntry {
+  memberCardIds: string[];
+}
+
+// ============================================================================
 // Player Hand Data
 // ============================================================================
 


### PR DESCRIPTION
## Per-stack discard zone (v1)

Adds an automated "discard zone" feature: create a discard zone for a stack, then **Discard** (shortcut `X`) any member card from anywhere on the table and it routes itself to that zone, landing **face-up** — starting a new pile or merging onto the zone's existing pile.

Closes the end-to-end loop: create zone → discard a member card → it lands face-up in the zone (new pile, then onto the existing pile).

### Design

- **Membership keyed by card id, not stack id.** Stack ids are minted fresh on every split/merge (`YjsActions.ts` `stackObjects`/`unstackCard`), so a stack id can't durably identify membership. Card ids are stable. This is also what the motivating use cases require — an encounter card that has migrated *into* a player deck no longer lives in its origin stack, yet must still route home.
- **A discard zone IS an `ObjectKind.Zone`**; the pile inside it is a `Stack` with `_containerId === zoneId`. No new heavy abstraction.
- **New top-level `discardZones` Y.Map** (zoneId → `{ memberCardIds }`), following the existing `hands` map pattern for CRDT sync + reload persistence.
- **Membership is a creation-time snapshot.** Dynamic/live membership is explicitly deferred to v2.

### What's included

| Bead | Change |
|------|--------|
| ct-55s | CRDT contract: `discardZones` Y.Map, `DiscardZoneEntry` type, store CRUD, `findDiscardZoneForCard`, deep observer |
| ct-plg | `createDiscardZoneForStack` — atomic zone creation + membership snapshot; stamps `_meta.isDiscardZone` |
| ct-ecl | `discard-card` action + `discardCardToZone` + `setCardFaceUp` (the loop-closer) |
| ct-utq | `create-discard-zone` context-menu action |
| ct-0ac | Renderer: discard zones show a warm-orange tint + 'Discard' label |

Reuses `unstackCard` / `stackObjects` / `moveObjects` / `createObject` — no duplicated stacking/extraction logic.

### Test plan (all run and green)

- ✅ `pnpm typecheck` (shared + app + server)
- ✅ `pnpm test` — 1364 app + 36 server unit tests (includes new coverage for `discardCardToZone` new-pile/merge/foreign-stack-extraction/face-up paths and `setCardFaceUp`)
- ✅ `pnpm build` (real bundler build)
- ✅ E2E `app/e2e/discard-zone.spec.ts` — 2/2 (first discard creates face-up pile with correct `_containerId`; second discard merges onto existing pile)

### Notes for review

- `Discard` uses shortcut `X` (`D` is taken by `draw-card`).
- Independent review pass found one would-be multiplayer-staleness concern in `discardCardToZone`; the snapshot reads were relocated inside the `transact()` for robustness/clarity (no behavior change).

### Deferred (filed as follow-up beads, intentionally out of v1 scope)

Dynamic membership (ct-xj4), travel animation (ct-c76), user-positioned/resizable zone (ct-rdu), remove/replace zone (ct-7zk), multi-zone disambiguation (ct-u8y), mid-stack/multi-select discard (ct-4o5); plus `isAvailable` top-card semantics (ct-2mg) and three E2E-coverage follow-ups (ct-650 foreign-stack E2E, ct-ozm visual assertion, ct-1l1 multiplayer/persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
