### PR TITLE
fix(content): remove legacy componentSet counter path (ct-4ky)

### DIFF
--- a/app/src/content/componentSet.test.ts
+++ b/app/src/content/componentSet.test.ts
@@ -30,9 +30,6 @@ const mockPack: AssetPack = {
   tokens: {
     damage: { image: 'damage.png', size: 'medium' },
   },
-  counters: {
-    threat: { label: 'Threat', min: 0, max: 99, start: 5 },
-  },
   mats: {
     playmat: { image: 'playmat.jpg', size: [1920, 1080] },
   },
@@ -44,7 +41,7 @@ const mockAssets: GameAssets = {
   cards: mockPack.cards!,
   cardSets: mockPack.cardSets!,
   tokens: mockPack.tokens!,
-  counters: mockPack.counters!,
+  counters: {},
   mats: mockPack.mats!,
   tokenTypes: {},
   statusTypes: {},
@@ -138,18 +135,6 @@ describe('resolveComponentSet', () => {
     const resolved = resolveComponentSet(set, mockAssets);
 
     expect(resolved.tokens).toEqual([{ ref: 'damage', label: 'Damage Token' }]);
-  });
-
-  it('should pass through counters unchanged', () => {
-    const set: ComponentSet = {
-      counters: [{ ref: 'threat', label: 'Threat Counter' }],
-    };
-
-    const resolved = resolveComponentSet(set, mockAssets);
-
-    expect(resolved.counters).toEqual([
-      { ref: 'threat', label: 'Threat Counter' },
-    ]);
   });
 
   it('should pass through mats unchanged', () => {
@@ -256,37 +241,6 @@ describe('instantiateComponentSet', () => {
     expect(token._faceUp).toBe(true);
   });
 
-  it('should create Counter objects', () => {
-    const set: ComponentSet = {
-      counters: [{ ref: 'threat', label: 'Threat Counter' }],
-    };
-
-    const resolved = resolveComponentSet(set, mockAssets);
-    const objects = instantiateComponentSet(resolved, mockAssets);
-
-    expect(objects.size).toBe(1);
-    const [, obj] = [...objects.entries()][0];
-
-    expect(obj._kind).toBe(ObjectKind.Counter);
-    expect(obj._meta.counterRef).toBe('threat');
-    expect(obj._meta.label).toBe('Threat Counter');
-    expect(obj._meta.value).toBe(5);
-    expect(obj._meta.min).toBe(0);
-    expect(obj._meta.max).toBe(99);
-  });
-
-  it('should override counter start value when specified', () => {
-    const set: ComponentSet = {
-      counters: [{ ref: 'threat', value: 10 }],
-    };
-
-    const resolved = resolveComponentSet(set, mockAssets);
-    const objects = instantiateComponentSet(resolved, mockAssets);
-
-    const [, obj] = [...objects.entries()][0];
-    expect(obj._meta.value).toBe(10);
-  });
-
   it('should create Mat objects', () => {
     const set: ComponentSet = {
       mats: [{ ref: 'playmat', label: 'Play Area' }],
@@ -340,7 +294,6 @@ describe('instantiateComponentSet', () => {
     const set: ComponentSet = {
       stacks: [{ label: 'Deck', faceUp: false, cards: ['01001'] }],
       tokens: [{ ref: 'damage' }],
-      counters: [{ ref: 'threat' }],
       mats: [{ ref: 'playmat' }],
       zones: [{ label: 'Zone', width: 100, height: 100 }],
     };
@@ -348,12 +301,11 @@ describe('instantiateComponentSet', () => {
     const resolved = resolveComponentSet(set, mockAssets);
     const objects = instantiateComponentSet(resolved, mockAssets);
 
-    expect(objects.size).toBe(5);
+    expect(objects.size).toBe(4);
 
     const kinds = [...objects.values()].map((o) => o._kind);
     expect(kinds).toContain(ObjectKind.Stack);
     expect(kinds).toContain(ObjectKind.Token);
-    expect(kinds).toContain(ObjectKind.Counter);
     expect(kinds).toContain(ObjectKind.Mat);
     expect(kinds).toContain(ObjectKind.Zone);
   });

--- a/app/src/content/componentSet.ts
+++ b/app/src/content/componentSet.ts
@@ -2,7 +2,6 @@ import type {
   ComponentSet,
   ComponentSetStack,
   ComponentSetToken,
-  ComponentSetCounter,
   ComponentSetMat,
   ComponentSetZone,
   GameAssets,
@@ -26,7 +25,6 @@ import { calculateRowLayout, type LayoutItem } from './componentSetLayout';
 export interface ResolvedComponentSet {
   stacks?: ResolvedComponentSetStack[];
   tokens?: ComponentSetToken[];
-  counters?: ComponentSetCounter[];
   mats?: ComponentSetMat[];
   zones?: ComponentSetZone[];
 }
@@ -69,10 +67,6 @@ export function resolveComponentSet(
 
   if (set.tokens) {
     resolved.tokens = [...set.tokens];
-  }
-
-  if (set.counters) {
-    resolved.counters = [...set.counters];
   }
 
   if (set.mats) {
@@ -150,12 +144,11 @@ function generateSortKey(index: number): string {
 // Default dimensions for layout spacing
 const DEFAULT_STACK_SIZE: [number, number] = [180, 252];
 const DEFAULT_TOKEN_SIZE: [number, number] = [64, 64];
-const DEFAULT_COUNTER_SIZE: [number, number] = [64, 64];
 const DEFAULT_MAT_SIZE: [number, number] = [400, 250];
 const DEFAULT_ZONE_SIZE: [number, number] = [100, 140];
 
 interface LayoutEntry {
-  type: 'stack' | 'token' | 'counter' | 'mat' | 'zone';
+  type: 'stack' | 'token' | 'mat' | 'zone';
   index: number; // Index within its type array
   row?: number;
 }
@@ -168,7 +161,7 @@ interface LayoutEntry {
  */
 export function instantiateComponentSet(
   set: ResolvedComponentSet,
-  gameAssets: GameAssets,
+  _gameAssets: GameAssets,
 ): Map<string, TableObject> {
   // Build flat list of items for layout calculation
   const layoutItems: LayoutItem[] = [];
@@ -193,17 +186,6 @@ export function instantiateComponentSet(
         row: set.tokens[i].row,
       });
       entries.push({ type: 'token', index: i, row: set.tokens[i].row });
-    }
-  }
-
-  if (set.counters) {
-    for (let i = 0; i < set.counters.length; i++) {
-      layoutItems.push({
-        width: DEFAULT_COUNTER_SIZE[0],
-        height: DEFAULT_COUNTER_SIZE[1],
-        row: set.counters[i].row,
-      });
-      entries.push({ type: 'counter', index: i, row: set.counters[i].row });
     }
   }
 
@@ -250,15 +232,6 @@ export function instantiateComponentSet(
       case 'token':
         obj = instantiateTokenFromDef(
           set.tokens![entry.index],
-          i,
-          pos.x,
-          pos.y,
-        );
-        break;
-      case 'counter':
-        obj = instantiateCounterFromDef(
-          set.counters![entry.index],
-          gameAssets,
           i,
           pos.x,
           pos.y,
@@ -316,32 +289,6 @@ function instantiateTokenFromDef(
     _selectedBy: null,
     _meta: { tokenRef: token.ref, label: token.label },
     _faceUp: true,
-  };
-}
-
-function instantiateCounterFromDef(
-  counter: ComponentSetCounter,
-  gameAssets: GameAssets,
-  zIndex: number,
-  x: number,
-  y: number,
-): TableObject {
-  const counterDef = gameAssets.counters[counter.ref];
-
-  return {
-    _kind: ObjectKind.Counter,
-    _containerId: null,
-    _pos: createPosition(x, y),
-    _sortKey: generateSortKey(zIndex),
-    _locked: false,
-    _selectedBy: null,
-    _meta: {
-      counterRef: counter.ref,
-      label: counter.label ?? counterDef?.label,
-      value: counter.value ?? counterDef?.start,
-      min: counterDef?.min,
-      max: counterDef?.max,
-    },
   };
 }
 

--- a/app/src/content/instantiate.test.ts
+++ b/app/src/content/instantiate.test.ts
@@ -55,14 +55,6 @@ const mockPack1: AssetPack = {
       size: 'medium',
     },
   },
-  counters: {
-    threat: {
-      label: 'Threat',
-      min: 0,
-      max: 99,
-      start: 5,
-    },
-  },
   mats: {
     playmat: {
       image: 'playmat.jpg',
@@ -103,7 +95,7 @@ const mockContent: GameAssets = {
   },
   cardSets: mockPack1.cardSets ?? {},
   tokens: mockPack1.tokens ?? {},
-  counters: mockPack1.counters ?? {},
+  counters: {},
   mats: mockPack1.mats ?? {},
   tokenTypes: {},
   statusTypes: {},
@@ -391,31 +383,6 @@ describe('instantiateScenario', () => {
     expect(token._meta.label).toBe('Damage Token');
   });
 
-  it('should instantiate counter', () => {
-    const scenario: Scenario = {
-      schema: 'ct-scenario@2',
-      id: 'test',
-      name: 'Test',
-      version: '1.0.0',
-      packs: [],
-      componentSet: {
-        counters: [{ ref: 'threat', label: 'Threat Counter' }],
-      },
-    };
-
-    const objects = instantiateScenario(scenario, mockContent);
-
-    expect(objects.size).toBe(1);
-    const counter = [...objects.values()][0];
-
-    expect(counter._kind).toBe(ObjectKind.Counter);
-    expect(counter._meta.counterRef).toBe('threat');
-    expect(counter._meta.label).toBe('Threat Counter');
-    expect(counter._meta.value).toBe(5);
-    expect(counter._meta.min).toBe(0);
-    expect(counter._meta.max).toBe(99);
-  });
-
   it('should instantiate mat', () => {
     const scenario: Scenario = {
       schema: 'ct-scenario@2',
@@ -498,18 +465,16 @@ describe('instantiateScenario', () => {
           },
         ],
         tokens: [{ ref: 'damage' }],
-        counters: [{ ref: 'threat' }],
       },
     };
 
     const objects = instantiateScenario(scenario, mockContent);
 
-    expect(objects.size).toBe(3);
+    expect(objects.size).toBe(2);
 
     const kinds = [...objects.values()].map((o) => o._kind);
     expect(kinds).toContain(ObjectKind.Stack);
     expect(kinds).toContain(ObjectKind.Token);
-    expect(kinds).toContain(ObjectKind.Counter);
   });
 
   it('should set common object properties', () => {

--- a/shared/src/content-types.ts
+++ b/shared/src/content-types.ts
@@ -204,13 +204,6 @@ export interface TokenDef {
   label?: string; // Optional display label
 }
 
-/** Counter definition — references a counter in the asset pack */
-export interface CounterDef {
-  ref: string; // Key in asset pack's `counters`
-  label?: string; // Optional display label
-  value?: number; // Override starting value (defaults to counter's `start`)
-}
-
 /** Mat definition — references a mat in the asset pack */
 export interface MatDef {
   ref: string; // Key in asset pack's `mats`
@@ -240,10 +233,6 @@ export interface ComponentSetToken extends TokenDef {
   row?: number;
 }
 
-export interface ComponentSetCounter extends CounterDef {
-  row?: number;
-}
-
 export interface ComponentSetMat extends MatDef {
   row?: number;
 }
@@ -256,7 +245,6 @@ export interface ComponentSetZone extends ZoneDef {
 export interface ComponentSet {
   stacks?: ComponentSetStack[];
   tokens?: ComponentSetToken[];
-  counters?: ComponentSetCounter[];
   mats?: ComponentSetMat[];
   zones?: ComponentSetZone[];
 }
@@ -432,8 +420,9 @@ export interface LoadableEntry<TData = unknown> {
  *
  * Note the distinction from the `Counter` asset-pack interface above:
  * `Counter` (`{label, min, max, start}`) is the *legacy* counter catalog
- * entry used by `ComponentSetCounter.ref`. `CounterTypeDef` is the
- * loadables-system payload for the typed-counter spawn flow.
+ * entry (formerly consumed by the now-removed `ComponentSetCounter.ref`
+ * path — see ct-4ky). `CounterTypeDef` is the loadables-system payload for
+ * the typed-counter spawn flow.
  */
 export interface CounterTypeDef {
   /** RGB number for the pill body (e.g. `0xf39c12`). */
@@ -516,11 +505,11 @@ export interface LayoutObject {
  * copies the template fields onto the instance, and assigns `currentValue`
  * (= `initialValue` when supplied, otherwise the type's `startingValue`).
  *
- * Distinct from `ComponentSetCounter` (legacy `ref`-based asset-pack catalog
- * entries — `Counter` interface in this file). Typed-counter spawns live on
- * the scenario root, NOT inside `componentSet`, to keep the two systems
- * legibly separated; the loadables-registry path is the forward-compatible
- * one and the asset-pack `counters` catalog is retained for back-compat.
+ * Distinct from the legacy `ref`-based asset-pack `Counter` catalog entries
+ * in this file (formerly wired up via `ComponentSetCounter`, removed in
+ * ct-4ky as dead code). Typed-counter spawns live on the scenario root, NOT
+ * inside `componentSet`, to keep the two systems legibly separated; the
+ * loadables-registry path is the forward-compatible one.
  *
  * Unknown `typeId` at load time is a non-fatal warning (the bad entry is
  * skipped, other spawns and the rest of the scenario still load).
@@ -553,9 +542,7 @@ export interface Scenario {
   /**
    * Typed counters to auto-spawn at scenario load (ct-x41). Each entry
    * references a counter type id declared by the active plugin via its
-   * `loadables[]` of `type: 'counter'`. Independent of `componentSet` —
-   * legacy `componentSet.counters` is the asset-pack-derived counter and
-   * stays untouched by this field.
+   * `loadables[]` of `type: 'counter'`. Independent of `componentSet`.
    */
   counters?: ScenarioCounterSpawn[];
 }


### PR DESCRIPTION
## Summary
- Removes `componentSet.ts`'s counter-instantiation path (`instantiateCounterFromDef`, the `'counter'` layout/switch case, `resolveComponentSet`'s counters passthrough) and the corresponding `ComponentSetCounter`/`CounterDef` types from `shared/src/content-types.ts`.
- This path built a Counter's `_meta` as `{counterRef, label, value, min, max}` — a shape the actual Counter renderer never reads (it only understands `_meta.currentValue`/`_meta.startingValue`, per `createCounterMeta`/`getCounterCurrentValue`). Any counter placed via this path would silently render 0 regardless of its configured value.
- Confirmed dead in production: scanned all 135 manifest/scenario JSON files in the local `cardtable-plugin-marvelchampions` checkout — zero uses of `componentSet.counters`. The shared-types doc comments already called `ComponentSetCounter` "legacy... retained for back-compat" relative to the current `ScenarioCounterSpawn` (`ct-x41`) mechanism, which is what live content actually uses.
- Leaves the `Counter` catalog interface and `GameAssets.counters` untouched — still used for asset-pack declarations.

Surfaced during code review of #119 (counter-reset-command); tracked as ct-4ky.

## Test plan
- [x] `pnpm typecheck` (all 3 workspaces) passes
- [x] `pnpm exec vitest run` (69 files, 1364 tests) passes
- [x] `pnpm -r run lint` / `format:check` pass
- [x] Repo-wide grep confirms no dangling references to `ComponentSetCounter`, `instantiateCounterFromDef`, or `CounterDef`

🤖 Generated with [Claude Code](https://claude.com/claude-code)